### PR TITLE
Bump ksoc-guard and ksoc-watch in stable chart version

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ksoc-plugins
-version: 1.0.4
+version: 1.0.5
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/assets/img/logo.svg

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -87,7 +87,7 @@ Example output:
 ```
 helm search repo ksoc
 NAME                     	CHART VERSION	APP VERSION	DESCRIPTION
-ksoc/ksoc-plugins        	1.0.0       	           	A Helm chart to run the KSOC plugins
+ksoc/ksoc-plugins        	1.0.5       	           	A Helm chart to run the KSOC plugins
 ```
 
 ### 4. Create cluster-specific values file

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -40,7 +40,7 @@ ksocGuard:
   image:
     # -- The image to use for the ksoc-guard deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-guard).
     repository: us.gcr.io/ksoc-public/ksoc-guard
-    tag: v0.0.64
+    tag: v0.0.66
   config:
     # -- Whether to block on error.
     BLOCK_ON_ERROR: false
@@ -104,7 +104,7 @@ ksocWatch:
   image:
     # -- The image to use for the kubewatcher deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/kubewatcher).
     repository: us.gcr.io/ksoc-public/ksoc-watch
-    tag: v0.0.39
+    tag: v0.0.40
   env: {}
   resources:
     limits:


### PR DESCRIPTION
Bump `ksoc-guard` and `ksoc-watch` plugin version in stable chart version.

Towards:

- https://github.com/ksoc-private/engineering-issues/issues/1385