### PR TITLE
Add support for watching networking objects

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ksoc-plugins
-version: 1.0.11
+version: 1.0.12
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/assets/img/logo.svg

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -87,7 +87,7 @@ Example output:
 ```
 helm search repo ksoc
 NAME                     	CHART VERSION	APP VERSION	DESCRIPTION
-ksoc/ksoc-plugins        	1.0.11      	           	A Helm chart to run the KSOC plugins
+ksoc/ksoc-plugins        	1.0.12      	           	A Helm chart to run the KSOC plugins
 ```
 
 ### 4. Create cluster-specific values file

--- a/stable/ksoc-plugins/templates/ksoc-watch/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-watch/rbac.yaml
@@ -71,6 +71,10 @@ rules:
     resources: [ "guardpolicies", "guardresults" ]
     verbs: [ "get", "list", "watch" ]
 
+  - apiGroups: [ "networking.k8s.io" ]
+    resources: [ "ingresses", "networkpolicies" ]
+    verbs: [ "get", "list", "watch" ]
+
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -102,7 +102,7 @@ ksocWatch:
   image:
     # -- The image to use for the ksoc-watch deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-watch).
     repository: us.gcr.io/ksoc-public/ksoc-watch
-    tag: v0.0.52
+    tag: v0.0.53
   env:
     # -- Whether to trigger reconciliation at startup.
     RECONCILIATION_AT_START: false


### PR DESCRIPTION
`ksoc-watch` plugin now supports ingesting of `Ingress` and `NetworkPolicy` objects.