### PR TITLE
Remove duplicate 'rules' line

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ksoc-plugins
-version: 1.0.21
+version: 1.0.22
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -15,8 +15,8 @@ maintainers:
 annotations:
   artifacthub.io/category: security
   artifacthub.io/changes: |
-    - kind: added
-      description: overview of each plugin to chart README
+    - kind: fixed
+      description: fix ksoc-watch RBAC syntax
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/templates/ksoc-watch/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-watch/rbac.yaml
@@ -53,7 +53,6 @@ metadata:
     app_version: {{ .Values.ksocWatch.image.tag | quote }}
     maintained_by: ksoc
 rules:
-rules:
   - apiGroups: [""]
     resources: ["namespaces", "nodes", "pods", "services", "serviceaccounts"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
This is incorrect kubernetes rbac syntax

Causes the latest version of the helm chart to fail with the following error ' Helm upgrade failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors: line 13: mapping key rules already defined at line 12'