### PR TITLE
use leastPrivileged in falco by default

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.0.26
+version: 1.0.27
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -149,6 +149,8 @@ falco:
   driver:
     enabled: true
     kind: modern-bpf
+    modern_bpf:
+      leastPrivileged: true
   falco:
     http_output:
       enabled: true


### PR DESCRIPTION
Falco support running in a least Privileged way: https://falco.org/docs/install-operate/running/#docker-least-privileged

Lets do that to be more secure by default