### PR TITLE
ksoc-watch reconciliation is using less memory

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.0.28
+version: 1.0.29
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -16,10 +16,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: added
-      description: Memory usage reporting in ksoc-watch
     - kind: fixed
-      description: Logs reporting with incorrect URL
+      description: Reconciliation in ksoc-watch is using less memory
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -129,7 +129,7 @@ Example output (chart version may differ):
 ```bash
 helm search repo ksoc
 NAME                     	CHART VERSION	APP VERSION	DESCRIPTION
-ksoc/ksoc-plugins        	1.0.28      	           	A Helm chart to run the KSOC plugins
+ksoc/ksoc-plugins        	1.0.29      	           	A Helm chart to run the KSOC plugins
 ```
 
 ### 4. Create cluster-specific values file

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -126,12 +126,10 @@ ksocWatch:
   image:
     # -- The image to use for the ksoc-watch deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-watch).
     repository: us.gcr.io/ksoc-public/ksoc-watch
-    tag: v1.0.1
+    tag: v1.0.3
   env:
     # -- Whether to trigger reconciliation at startup.
     RECONCILIATION_AT_START: false
-    # -- How often should reconciliation be triggered.
-    RECONCILIATION_INTERVAL: 24h
   resources:
     limits:
       cpu: 250m


### PR DESCRIPTION
Reconciliation process used to list all resources at once which caused memory spikes for large clusters. Fixed version is paginating through resources and process them in batches.