### PR TITLE
Update ksoc-guard to enable silencing of logs

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.0.30
+version: 1.0.31
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -17,7 +17,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: Set falco image pull policy to Always.
+      description: Disable ksoc-guard warning logs by default.
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -38,7 +38,7 @@ ksocGuard:
   image:
     # -- The image to use for the ksoc-guard deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-guard).
     repository: us.gcr.io/ksoc-public/ksoc-guard
-    tag: v1.0.0
+    tag: v1.0.1
   config:
     # -- Whether to block on error.
     BLOCK_ON_ERROR: false
@@ -46,6 +46,8 @@ ksocGuard:
     BLOCK_ON_POLICY_VIOLATION: false
     # -- Whether to block on timeout.
     BLOCK_ON_TIMEOUT: false
+    # -- Whether to enable warning logs.
+    ENABLE_WARNING_LOGS: false
     # -- The log level to use.
     LOG_LEVEL: info
   resources:


### PR DESCRIPTION
Update ksoc-guard to provide an environment variable to enable ksoc-guard warning logs when new resources are introduced to the cluster that violate policies.  Set to `false` by default.