### PR TITLE
Bump ksoc-sbom plugin to fix medium vulnerability

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.0.35
+version: 1.0.36
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -16,8 +16,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: added
-      description: Added custom rules to generate file access and executable profiles to show reachable package vulnerabilities.
+    - kind: changed
+      description: Updated the ksoc-sbom image to v1.0.2 to fix a medium vulnerability(GHSA-jq35-85cj-fj4p). See https://github.com/moby/moby/security/advisories/GHSA-jq35-85cj-fj4p
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -129,7 +129,7 @@ Example output (chart version may differ):
 ```bash
 helm search repo ksoc
 NAME                     	CHART VERSION	APP VERSION	DESCRIPTION
-ksoc/ksoc-plugins        	1.0.32      	           	A Helm chart to run the KSOC plugins
+ksoc/ksoc-plugins        	1.0.36      	           	A Helm chart to run the KSOC plugins
 ```
 
 ### 4. Create cluster-specific values file

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -155,7 +155,7 @@ ksocSbom:
   image:
     # -- The image to use for the ksoc-sbom deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-sbom).
     repository: us.gcr.io/ksoc-public/ksoc-sbom
-    tag: v1.0.1
+    tag: v1.0.2
   env: {}
   resources:
     requests:


### PR DESCRIPTION
Bump `ksoc-sbom` plugin to fix Medium vulnerability. 

Details:
![Screenshot 2023-11-21 at 12 48 30](https://github.com/ksoclabs/ksoc-plugins-helm-chart/assets/4962812/96d0376b-5375-46ed-99d6-5d8e7588863b)
