### PR TITLE
Updates Helm Chart to support new plugin versions with multi architec…

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.0.39
+version: 1.1.0
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -20,7 +20,7 @@ ksocBootstrapper:
   image:
     # -- The image to use for the ksoc-bootstrapper deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-bootstrapper).
     repository: us.gcr.io/ksoc-public/ksoc-bootstrapper
-    tag: v1.0.1
+    tag: 1.1.0
   env: {}
   resources:
     limits:
@@ -38,7 +38,7 @@ ksocGuard:
   image:
     # -- The image to use for the ksoc-guard deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-guard).
     repository: us.gcr.io/ksoc-public/ksoc-guard
-    tag: v1.0.2
+    tag: 1.1.0
   config:
     # -- Whether to block on error.
     BLOCK_ON_ERROR: false
@@ -70,7 +70,7 @@ ksocRuntime:
   reporter:
     image:
       repository: us.gcr.io/ksoc-public/runtime-reporter
-      tag: v1.0.0
+      tag: 1.1.0
     env:
       LOG_LEVEL: info
     resources:
@@ -159,7 +159,7 @@ ksocSbom:
   image:
     # -- The image to use for the ksoc-sbom deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-sbom).
     repository: us.gcr.io/ksoc-public/ksoc-sbom
-    tag: v1.0.2
+    tag: 1.1.0
   env: {}
   resources:
     requests:
@@ -179,7 +179,7 @@ ksocSync:
   image:
     # -- The image to use for the ksoc-sync deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-sync).
     repository: us.gcr.io/ksoc-public/ksoc-sync
-    tag: v1.0.1
+    tag: 1.1.0
   env: {}
   resources:
     limits:
@@ -197,7 +197,7 @@ ksocWatch:
   image:
     # -- The image to use for the ksoc-watch deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-watch).
     repository: us.gcr.io/ksoc-public/ksoc-watch
-    tag: v1.0.4
+    tag: 1.1.0
   env:
     # -- Whether to trigger reconciliation at startup.
     RECONCILIATION_AT_START: false


### PR DESCRIPTION
Towards ENG-1225

Updates our images with new tags that support multiple architectures. 

With AMD64 Nodes:
<img width="526" alt="Screenshot 2023-12-21 at 11 11 35 PM" src="https://github.com/ksoclabs/ksoc-plugins-helm-chart/assets/29550103/a91578d8-3774-4a0d-b1ed-3bde30bb412c">

With ARM64 Nodes:
![Uploading Screenshot 2023-12-21 at 11.15.38 PM.png…]()

