### PR TITLE
Change Image Plugin Version

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.1.0
+version: 1.1.1
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -16,8 +16,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: changed
-      description: ksocSbom.resources.limits.cpu should be a string
+    - kind: fixed
+      description: Use correct plugin versions.
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -20,7 +20,7 @@ ksocBootstrapper:
   image:
     # -- The image to use for the ksoc-bootstrapper deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-bootstrapper).
     repository: us.gcr.io/ksoc-public/ksoc-bootstrapper
-    tag: 1.1.0
+    tag: v1.0.1
   env: {}
   resources:
     limits:
@@ -38,7 +38,7 @@ ksocGuard:
   image:
     # -- The image to use for the ksoc-guard deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-guard).
     repository: us.gcr.io/ksoc-public/ksoc-guard
-    tag: 1.1.0
+    tag: v1.0.2
   config:
     # -- Whether to block on error.
     BLOCK_ON_ERROR: false
@@ -70,7 +70,7 @@ ksocRuntime:
   reporter:
     image:
       repository: us.gcr.io/ksoc-public/runtime-reporter
-      tag: 1.1.0
+      tag: v1.0.0
     env:
       LOG_LEVEL: info
     resources:
@@ -159,7 +159,7 @@ ksocSbom:
   image:
     # -- The image to use for the ksoc-sbom deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-sbom).
     repository: us.gcr.io/ksoc-public/ksoc-sbom
-    tag: 1.1.0
+    tag: v1.0.2
   env: {}
   resources:
     requests:
@@ -179,7 +179,7 @@ ksocSync:
   image:
     # -- The image to use for the ksoc-sync deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-sync).
     repository: us.gcr.io/ksoc-public/ksoc-sync
-    tag: 1.1.0
+    tag: v1.0.1
   env: {}
   resources:
     limits:
@@ -197,7 +197,7 @@ ksocWatch:
   image:
     # -- The image to use for the ksoc-watch deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-watch).
     repository: us.gcr.io/ksoc-public/ksoc-watch
-    tag: 1.1.0
+    tag: v1.0.4
   env:
     # -- Whether to trigger reconciliation at startup.
     RECONCILIATION_AT_START: false


### PR DESCRIPTION
On the latest release of 1.1.0, the image where not quite built correctly. This PR reverts the changes in the images back to the original version for now.
