### PR TITLE
Adds a Github Action To Push Helm Chart To ECR

### DIFF
--- a/.github/workflows/build-marketplace-helm-chart.yaml
+++ b/.github/workflows/build-marketplace-helm-chart.yaml
@@ -1,0 +1,46 @@
+name: build-marketplace-helm-chart
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  build-marketplace-helm-chart:
+    name: Build AWS Marketplace Helm Chart
+    runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'renovate') == false
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Replace GCR Images with ECR Images
+      run: ./scripts/replace_repositories.sh
+
+    - name: Install Helm
+      uses: azure/setup-helm@v3
+      with:
+        version: 'v3.13.2'
+
+    - name: Assume Marketplace Integration Role
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ vars.AWS_MARKETPLACE_ROLE }}
+        role-session-name: github-action-build-images
+        aws-access-key-id: ${{ secrets.AWS_GITHUB_RUNNER_ACCESS_KEY }}
+        aws-secret-access-key: ${{ secrets.AWS_GITHUB_RUNNER_SECRET_KEY }}
+        aws-region: ${{ vars.AWS_MARKETPLACE_REGION }}
+
+    - name: Login to ECR with Helm
+      env:
+        REGISTRY: ${{ vars.AWS_MARKETPLACE_REGISTRY }}
+      run: aws ecr get-login-password --region us-east-1 | helm registry login --username AWS --password-stdin $REGISTRY
+
+    - name: Package Helm Chart
+      run: helm package stable/ksoc-plugins
+
+    - name: Push helm chart to Amazon ECR
+      env:
+        REGISTRY: ${{ vars.AWS_MARKETPLACE_REGISTRY }}
+        HELM_EXPERIMENTAL_OCI: 1
+      run: helm push ksoc-plugins-$(git describe --tags --always).tgz oci://$REGISTRY/

--- a/scripts/replace_repositories.sh
+++ b/scripts/replace_repositories.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+FILE="../stable/ksoc-plugins/values.yaml"
+FALCO_DS_FILE="../stable/ksoc-plugins/templates/falco/falco-ds.yaml"
+
+GCR_REGISTRY_NAME="us.gcr.io/ksoc-public"
+FALCO_SEARCH="falcosecurity"
+
+ECR_REGISTRY_NAME="709825985650.dkr.ecr.us-east-1.amazonaws.com/ksoc-labs"
+
+sed -i "s|$GCR_REGISTRY_NAME|$ECR_REGISTRY_NAME|g" "$FILE"
+sed -i "s|$FALCO_SEARCH|$ECR_REGISTRY_NAME|g" "$FALCO_DS_FILE"

--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.1.3
+version: 1.1.4
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -17,7 +17,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: added
-      description: Updates plugin images with versions that get pushed to GCR and ECR.
+      description: Pushes chart to ArtifactHub and AWS Marketplace ECR
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source


### PR DESCRIPTION
Adds a Github Action to push the helm chart to ECR.

Example run of a version 0.0.001
<img width="1067" alt="Screenshot 2024-01-05 at 12 23 54 AM" src="https://github.com/ksoclabs/ksoc-plugins-helm-chart/assets/29550103/8951f4aa-aa8c-4834-8763-bcd7152770e8">
