### PR TITLE
Replace Git Tag With A Search For The tgz File

### DIFF
--- a/.github/workflows/build-marketplace-helm-chart.yaml
+++ b/.github/workflows/build-marketplace-helm-chart.yaml
@@ -43,4 +43,4 @@ jobs:
       env:
         REGISTRY: ${{ vars.AWS_MARKETPLACE_REGISTRY }}
         HELM_EXPERIMENTAL_OCI: 1
-      run: helm push ksoc-plugins-$(git describe --tags --always).tgz oci://$REGISTRY/
+      run: helm push $(ls | grep '.tgz') oci://$REGISTRY/


### PR DESCRIPTION
`git describe --tags --always` was returning the sha and not the tag. This resulted in `Error: ksoc-plugins-9bf5f95.tgz: no such file` on the last run. By changing the command to search for the generated tgz file, we can move off of our dependency on the tag aligning with the generated helm chart. 