### PR TITLE
Bump plugins versions

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.1.7
+version: 1.1.8
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -16,8 +16,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: changed
-      description: Updates usage instructions to point to our documentation
+    - kind: security
+      description: Update dependencies to fix security vulnerabilities
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -129,7 +129,7 @@ Example output (chart version may differ):
 ```bash
 helm search repo ksoc
 NAME                     	CHART VERSION	APP VERSION	DESCRIPTION
-ksoc/ksoc-plugins        	1.1.2        	           	A Helm chart to run the KSOC plugins
+ksoc/ksoc-plugins        	1.1.8        	           	A Helm chart to run the KSOC plugins
 ```
 
 ### 4. Create cluster-specific values file

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -20,7 +20,7 @@ ksocBootstrapper:
   image:
     # -- The image to use for the ksoc-bootstrapper deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-bootstrapper).
     repository: us.gcr.io/ksoc-public/ksoc-bootstrapper
-    tag: v1.1.2
+    tag: v1.1.3
   env: {}
   resources:
     limits:
@@ -38,7 +38,7 @@ ksocGuard:
   image:
     # -- The image to use for the ksoc-guard deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-guard).
     repository: us.gcr.io/ksoc-public/ksoc-guard
-    tag: v1.1.2
+    tag: v1.1.4
   config:
     # -- Whether to block on error.
     BLOCK_ON_ERROR: false
@@ -70,7 +70,7 @@ ksocRuntime:
   reporter:
     image:
       repository: us.gcr.io/ksoc-public/runtime-reporter
-      tag: v1.1.2
+      tag: v1.1.3
     env:
       LOG_LEVEL: info
     resources:
@@ -159,7 +159,7 @@ ksocSbom:
   image:
     # -- The image to use for the ksoc-sbom deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-sbom).
     repository: us.gcr.io/ksoc-public/ksoc-sbom
-    tag: v1.1.4
+    tag: v1.1.6
   env: {}
   resources:
     requests:
@@ -179,7 +179,7 @@ ksocSync:
   image:
     # -- The image to use for the ksoc-sync deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-sync).
     repository: us.gcr.io/ksoc-public/ksoc-sync
-    tag: v1.1.2
+    tag: v1.1.3
   env: {}
   resources:
     limits:
@@ -197,7 +197,7 @@ ksocWatch:
   image:
     # -- The image to use for the ksoc-watch deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-watch).
     repository: us.gcr.io/ksoc-public/ksoc-watch
-    tag: v1.1.2
+    tag: v1.1.3
   env:
     # -- Whether to trigger reconciliation at startup.
     RECONCILIATION_AT_START: false


### PR DESCRIPTION
#### What this PR does / why we need it

This PR contains new versions of ksoc-plugins to address security vulnerabilities. See: 
![Screenshot 2024-01-31 at 10 15 35](https://github.com/ksoclabs/ksoc-plugins-helm-chart/assets/4962812/8bcbfdc8-cb92-4859-997b-b01ebcc11d69)

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md](./stable/ksoc-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
