### PR TITLE
Removes comments in values.yaml when pushing to ECR

### DIFF
--- a/.github/workflows/build-marketplace-helm-chart.yaml
+++ b/.github/workflows/build-marketplace-helm-chart.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Replace GCR Images with ECR Images
+    - name: Replace Images and Remove Comments In values.yaml
       run: ./scripts/replace_repositories.sh
 
     - name: Install Helm

--- a/scripts/replace_repositories.sh
+++ b/scripts/replace_repositories.sh
@@ -10,3 +10,5 @@ ECR_REGISTRY_NAME="709825985650.dkr.ecr.us-east-1.amazonaws.com/ksoc-labs"
 
 sed -i "s|$GCR_REGISTRY_NAME|$ECR_REGISTRY_NAME|g" "$FILE"
 sed -i "s|$FALCO_SEARCH|$ECR_REGISTRY_NAME|g" "$FALCO_DS_FILE"
+sed -i '/# --/d' "$FILE"
+

--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.1.9
+version: 1.1.10
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -16,8 +16,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: added
-      description: Added a combined API key to install the Helm Chart
+    - kind: Removed
+      description: Removed comments in values yaml file to reduce confusion when pushing to the AWS Marketplace
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source


### PR DESCRIPTION
Our comments within our values.yaml file causes confusion due to some references to GCR. The EKS Marketplace does not utilize these comments, so the best way is to remove the confusion is to delete the comments  before we push to ECR. 

