### PR TITLE
Fixes formattin in replace_repositories script

### DIFF
--- a/scripts/replace_repositories.sh
+++ b/scripts/replace_repositories.sh
@@ -11,4 +11,3 @@ ECR_REGISTRY_NAME="709825985650.dkr.ecr.us-east-1.amazonaws.com/ksoc-labs"
 sed -i "s|$GCR_REGISTRY_NAME|$ECR_REGISTRY_NAME|g" "$FILE"
 sed -i "s|$FALCO_SEARCH|$ECR_REGISTRY_NAME|g" "$FALCO_DS_FILE"
 sed -i '/# --/d' "$FILE"
-


### PR DESCRIPTION
Fixes the formatting in the replace_repositories.sh script. This was causing our pre-commit hooks to fail.