### PR TITLE
Mark 1.2.0 release as generally available

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -24,4 +24,3 @@ annotations:
       url: https://github.com/ksoclabs/ksoc-plugins-helm-chart
     - name: support
       url: https://github.com/ksoclabs/ksoc-plugins-helm-chart/issues
-  artifacthub.io/prerelease: "true"


### PR DESCRIPTION
This marks release `1.2.0` as generally available following testing.