### PR TITLE
Update ksoc-sbom to fix a security vuln. Improve Custom Resource support in ksoc-watch.

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -26,4 +26,3 @@ annotations:
       url: https://github.com/ksoclabs/ksoc-plugins-helm-chart
     - name: support
       url: https://github.com/ksoclabs/ksoc-plugins-helm-chart/issues
-  artifacthub.io/prerelease: "true"


### PR DESCRIPTION
This removes prerelease annotation.