### PR TITLE
Adds metacollector to our Helm Chart

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.2.4
+version: 1.2.5
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -16,8 +16,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Fixed bug in Falco component
+    - kind: added
+      description: Adds k8s-metacollector to allow Falco to add Kubernetes Metadata to events
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/templates/falco/falco-configmap.yaml
+++ b/stable/ksoc-plugins/templates/falco/falco-configmap.yaml
@@ -41,7 +41,8 @@ data:
     libs_logger:
       enabled: false
       severity: debug
-    load_plugins: []
+    load_plugins:
+      - k8smeta
     log_level: info
     log_stderr: true
     log_syslog: true
@@ -58,8 +59,10 @@ data:
       libbpf_stats_enabled: true
       output_rule: true
       resource_utilization_enabled: true
-    modern_bpf:
-      cpus_for_each_syscall_buffer: 2
+    engine:
+      kind: modern_ebpf
+      modern_ebpf:
+        cpus_for_each_buffer: 2
     output_timeout: 2000
     outputs:
       max_burst: 1000
@@ -67,6 +70,12 @@ data:
     outputs_queue:
       capacity: 0
     plugins:
+    - init_config:
+        collectorHostname: k8s-metacollector.{{ .Release.Namespace  }}.svc
+        collectorPort: 45000
+        nodeName: ${FALCO_K8S_NODE_NAME}
+      library_path: libk8smeta.so
+      name: k8smeta
     - init_config: null
       library_path: libk8saudit.so
       name: k8saudit

--- a/stable/ksoc-plugins/templates/falco/falco-ds.yaml
+++ b/stable/ksoc-plugins/templates/falco/falco-ds.yaml
@@ -22,7 +22,6 @@ spec:
       containers:
       - args:
         - /usr/bin/falco
-        - --modern-bpf
         - --cri
         - /run/containerd/containerd.sock
         - --cri
@@ -92,6 +91,8 @@ spec:
           subPath: falco.yaml
         - mountPath: /etc/falco/rules.d/
           name: ksoc-runtime-profile-rules-config
+        - mountPath: /usr/share/falco/plugins
+          name: plugins-install-dir
       - args:
         - artifact
         - follow

--- a/stable/ksoc-plugins/templates/falco/falcoctl-configmap.yaml
+++ b/stable/ksoc-plugins/templates/falco/falcoctl-configmap.yaml
@@ -9,6 +9,7 @@ data:
     artifact:
       allowedTypes:
       - rulesfile
+      - plugin
       follow:
         every: 6h
         falcoversions: http://localhost:8765/versions
@@ -20,6 +21,7 @@ data:
         pluginsDir: /plugins
         refs:
         - falco-rules:2
+        - ghcr.io/falcosecurity/plugins/plugin/k8smeta:0.1.0
         resolveDeps: false
         rulesfilesDir: /rulesfiles
     indexes:

--- a/stable/ksoc-plugins/templates/metacollector/clusterrole.yaml
+++ b/stable/ksoc-plugins/templates/metacollector/clusterrole.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ksocRuntime.enabled  }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ksoc-k8s-metacollector
+  labels:
+    app.kubernetes.io/name: ksoc-k8s-metacollector
+    app.kubernetes.io/instance: k8s-metacollector
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - namespaces
+      - pods
+      - replicationcontrollers
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}

--- a/stable/ksoc-plugins/templates/metacollector/clusterrolebinding.yaml
+++ b/stable/ksoc-plugins/templates/metacollector/clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.ksocRuntime.enabled  }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8s-metacollector
+  labels:
+    app.kubernetes.io/name: ksoc-k8s-metacollector
+    app.kubernetes.io/instance: k8s-metacollector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ksoc-k8s-metacollector
+subjects:
+  - kind: ServiceAccount
+    name: ksoc-k8s-metacollector
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/ksoc-plugins/templates/metacollector/deployment.yaml
+++ b/stable/ksoc-plugins/templates/metacollector/deployment.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.ksocRuntime.enabled  }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8s-metacollector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: ksoc-k8s-metacollector
+    app.kubernetes.io/instance: k8s-metacollector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ksoc-k8s-metacollector
+      app.kubernetes.io/instance: k8s-metacollector
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ksoc-k8s-metacollector
+        app.kubernetes.io/instance: k8s-metacollector
+    spec:
+      serviceAccountName: ksoc-k8s-metacollector
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+        - name: k8s-metacollector
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+          image: "docker.io/falcosecurity/k8s-metacollector:0.1.0"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /meta-collector
+          args:
+            - run
+          ports:
+            - name: "broker-grpc"
+              containerPort: 45000
+              protocol: TCP
+            - name: "health-probe"
+              containerPort: 8081
+              protocol: TCP
+            - name: "metrics"
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 45
+            periodSeconds: 15
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+          resources:
+            {}
+{{- end }}

--- a/stable/ksoc-plugins/templates/metacollector/service.yaml
+++ b/stable/ksoc-plugins/templates/metacollector/service.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.ksocRuntime.enabled  }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8s-metacollector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: ksoc-k8s-metacollector
+    app.kubernetes.io/instance: k8s-metacollector
+spec:
+  type: ClusterIP
+  ports:
+    - name: broker-grpc
+      port: 45000
+      protocol: TCP
+      targetPort: broker-grpc
+    - name: health-probe
+      port: 8081
+      protocol: TCP
+      targetPort: health-probe
+    - name: metrics
+      port: 8080
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/name: ksoc-k8s-metacollector
+    app.kubernetes.io/instance: k8s-metacollector
+{{- end }}

--- a/stable/ksoc-plugins/templates/metacollector/serviceaccount.yaml
+++ b/stable/ksoc-plugins/templates/metacollector/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.ksocRuntime.enabled  }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ksoc-k8s-metacollector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: ksoc-k8s-metacollector
+    app.kubernetes.io/instance: k8s-metacollector
+{{- end }}


### PR DESCRIPTION
Adds the Falco k8s-metacollector to our Helm Chart. This is needed by Falco to attach Kubernetes Metadata to events generated by Falco. 