### PR TITLE
Add tolerations and metacollector configuration to the Helm Chart

### DIFF
--- a/scripts/create_changeset.sh
+++ b/scripts/create_changeset.sh
@@ -13,7 +13,7 @@ AWS_MARKETPLACE_PRODUCT_ID="prod-m7tlrvfq6yjzu"
 
 KSOC_RUNTIME_IMAGE=$(yq e ".ksocRuntime.reporter.image.repository" $VALUES_FILE_PATH):$(yq e ".ksocRuntime.reporter.image.tag" $VALUES_FILE_PATH)
 
-CONTAINER_IMAGES="709825985650.dkr.ecr.us-east-1.amazonaws.com/ksoc-labs/falco-no-driver:0.36.2 709825985650.dkr.ecr.us-east-1.amazonaws.com/ksoc-labs/falcoctl:0.6.2 $KSOC_RUNTIME_IMAGE "
+CONTAINER_IMAGES="709825985650.dkr.ecr.us-east-1.amazonaws.com/ksoc-labs/falco-no-driver:0.37.1 709825985650.dkr.ecr.us-east-1.amazonaws.com/ksoc-labs/falcoctl:0.7.1 $KSOC_RUNTIME_IMAGE "
 
 
 PRODUCT_TITLE=$(aws marketplace-catalog describe-entity --entity-id "${AWS_MARKETPLACE_PRODUCT_ID}" --catalog AWSMarketplace --region us-east-1 | jq -r '.Details | fromjson | .Description.ProductTitle')

--- a/scripts/replace_repositories.sh
+++ b/scripts/replace_repositories.sh
@@ -6,8 +6,12 @@ FALCO_DS_FILE="./stable/ksoc-plugins/templates/falco/falco-ds.yaml"
 GCR_REGISTRY_NAME="us.gcr.io/ksoc-public"
 FALCO_SEARCH="falcosecurity"
 
+METADATA_COLLECTOR_LOCATION="./stable/ksoc-plugins/templates/metacollector/deployment.yaml"
+METADATA_COLLECTOR_REGISTRY="docker.io/falcosecurity"
+
 ECR_REGISTRY_NAME="709825985650.dkr.ecr.us-east-1.amazonaws.com/ksoc-labs"
 
 sed -i "s|$GCR_REGISTRY_NAME|$ECR_REGISTRY_NAME|g" "$FILE"
 sed -i "s|$FALCO_SEARCH|$ECR_REGISTRY_NAME|g" "$FALCO_DS_FILE"
+sed -i "s|$METADATA_COLLECTOR_REGISTRY|$ECR_REGISTRY_NAME|g" "$METADATA_COLLECTOR_LOCATION"
 sed -i '/# --/d' "$FILE"

--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.2.5
+version: 1.2.7
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -17,7 +17,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: added
-      description: Adds k8s-metacollector to allow Falco to add Kubernetes Metadata to events
+      description: Adds k8s-metacollector and updated Falco versions to the AWS Marketplace Registries and adds tolerations to the Falco Daemonset
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.2.7
+version: 1.2.6
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg

--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -17,7 +17,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: added
-      description: Adds k8s-metacollector and updated Falco versions to the AWS Marketplace Registries and adds tolerations to the Falco Daemonset
+      description: Adds k8s-metacollector and adds new Falco versions to the AWS Marketplace Registries. Adds configuration tolerations to the Falco Daemonset and Metacollector.
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/templates/falco/falco-ds.yaml
+++ b/stable/ksoc-plugins/templates/falco/falco-ds.yaml
@@ -58,12 +58,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         resources:
-          limits:
-            cpu: "1"
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 512Mi
+{{ toYaml .Values.falco.resources | indent 10 }}
         securityContext:
           capabilities:
             add:
@@ -135,11 +130,10 @@ spec:
       serviceAccount: {{ .Values.falco.fullnameOverride }}
       serviceAccountName: {{ .Values.falco.fullnameOverride }}
       terminationGracePeriodSeconds: 30
+      {{- with .Values.falco.tolerations }}
       tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
+{{ toYaml . | indent 6 }}
+  {{- end }}
       volumes:
       - emptyDir: {}
         name: plugins-install-dir

--- a/stable/ksoc-plugins/templates/metacollector/deployment.yaml
+++ b/stable/ksoc-plugins/templates/metacollector/deployment.yaml
@@ -62,5 +62,13 @@ spec:
             periodSeconds: 15
             timeoutSeconds: 5
           resources:
-            {}
+{{ toYaml .Values.metacollector.resources | indent 12 }}
+          {{- with .Values.metacollector.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.metacollector.tolerations }}
+      tolerations:
+{{ toYaml . | indent 6 }}
+      {{- end }}
 {{- end }}

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -235,10 +235,10 @@ ksocWatch:
     denylist: []
 
 # -- Falco Daemonset configuration. The tolerations and resources are what are provided by default.
-# -- You can change them if need be. 
+# -- You can change them if need be.
 falco:
   fullnameOverride: ksoc-runtime-ds
-  tolerations: 
+  tolerations:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master
   - effect: NoSchedule
@@ -251,8 +251,8 @@ falco:
       cpu: 100m
       memory: 512Mi
 
-# -- The Falco k8s-metacollector is disabled by default. It will only be created if 
-# -- ksoc.ksoc-runtime is enabled. These values are blank by default in the metacollector. 
+# -- The Falco k8s-metacollector is disabled by default. It will only be created if
+# -- ksoc.ksoc-runtime is enabled. These values are blank by default in the metacollector.
 # -- You can extend them if needed.
 metacollector:
   resources: {}

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -234,5 +234,27 @@ ksocWatch:
     allowlist: []
     denylist: []
 
+# -- Falco Daemonset configuration. The tolerations and resources are what are provided by default.
+# -- You can change them if need be. 
 falco:
   fullnameOverride: ksoc-runtime-ds
+  tolerations: 
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+  resources:
+    limits:
+      cpu: "1"
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 512Mi
+
+# -- The Falco k8s-metacollector is disabled by default. It will only be created if 
+# -- ksoc.ksoc-runtime is enabled. These values are blank by default in the metacollector. 
+# -- You can extend them if needed.
+metacollector:
+  resources: {}
+  tolerations: []
+  nodeSelector: {}


### PR DESCRIPTION
We need to be able to set tolerations on the Falco Daemonset. 
The metacollector and updated version of Falco were missing from the AWS Marketplace Registry. This PR adds that as well.
