### PR TITLE
Fixes typo in tag name for k8s-metacollector and makes k8s-metacollector optional

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -16,8 +16,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Corrects typo in metacollector tag name
+    - kind: changed
+      description: Makes metacollector optional and fixes typo in metacollector tag name
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.2.9
+version: 1.2.10
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -17,7 +17,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: fixed
-      description: Specifies the docker.io image repo name for Falco images
+      description: Corrects typo in metacollector tag name
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/templates/falco/falco-configmap.yaml
+++ b/stable/ksoc-plugins/templates/falco/falco-configmap.yaml
@@ -41,8 +41,10 @@ data:
     libs_logger:
       enabled: false
       severity: debug
+    {{- if .Values.metacollector.enabled }}
     load_plugins:
       - k8smeta
+    {{- end }}
     log_level: info
     log_stderr: true
     log_syslog: true
@@ -70,12 +72,14 @@ data:
     outputs_queue:
       capacity: 0
     plugins:
+    {{- if .Values.metacollector.enabled }}
     - init_config:
         collectorHostname: k8s-metacollector.{{ .Release.Namespace  }}.svc
         collectorPort: 45000
         nodeName: ${FALCO_K8S_NODE_NAME}
       library_path: libk8smeta.so
       name: k8smeta
+    {{- end }}
     - init_config: null
       library_path: libk8saudit.so
       name: k8saudit

--- a/stable/ksoc-plugins/templates/metacollector/clusterrole.yaml
+++ b/stable/ksoc-plugins/templates/metacollector/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ksocRuntime.enabled  }}
+{{- if and .Values.ksocRuntime.enabled .Values.metacollector.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/stable/ksoc-plugins/templates/metacollector/clusterrolebinding.yaml
+++ b/stable/ksoc-plugins/templates/metacollector/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ksocRuntime.enabled  }}
+{{- if and .Values.ksocRuntime.enabled .Values.metacollector.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/stable/ksoc-plugins/templates/metacollector/deployment.yaml
+++ b/stable/ksoc-plugins/templates/metacollector/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ksocRuntime.enabled  }}
+{{- if and .Values.ksocRuntime.enabled .Values.metacollector.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/stable/ksoc-plugins/templates/metacollector/service.yaml
+++ b/stable/ksoc-plugins/templates/metacollector/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ksocRuntime.enabled  }}
+{{- if and .Values.ksocRuntime.enabled .Values.metacollector.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/stable/ksoc-plugins/templates/metacollector/serviceaccount.yaml
+++ b/stable/ksoc-plugins/templates/metacollector/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ksocRuntime.enabled  }}
+{{- if and .Values.ksocRuntime.enabled .Values.metacollector.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -259,9 +259,9 @@ falco:
       memory: 512Mi
 
 # -- The Falco k8s-metacollector is disabled by default. It will only be created if
-# -- ksoc.ksoc-runtime is enabled. These values are blank by default in the metacollector.
-# -- You can extend them if needed.
+# -- ksoc-runtime is enabled and metacollector is set to be enabled.
 metacollector:
+  enabled: false
   image:
     repository: docker.io/falcosecurity/k8s-metacollector
     tag: 0.1.0

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -264,7 +264,7 @@ falco:
 metacollector:
   image:
     repository: docker.io/falcosecurity/k8s-metacollector
-    tag: v0.1.0
+    tag: 0.1.0
   resources: {}
   tolerations: []
   nodeSelector: {}


### PR DESCRIPTION
The tag name was incorrectly copied over when the image name and value was copied over to values.yaml . This PR corrects the typo. 

We would also like to allow our customers to enable the metacollector if they want to. A new `metacollector.enabled` value is added to the helm chart. If it's set, then we will install all of the resources for the metacollector and install the Falco plugin to use the metacollector. 