### PR TITLE
Makes ksoc-access-key creation optional if no secret keys are passed to it

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.2.10
+version: 1.2.11
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -17,7 +17,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: Makes metacollector optional and fixes typo in metacollector tag name
+      description: Makes the creation of the ksoc api secret optional when no secret keys are passed.
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/templates/access-key-secret.yaml
+++ b/stable/ksoc-plugins/templates/access-key-secret.yaml
@@ -1,4 +1,4 @@
-{{ if not (or .Values.ksoc.accessKeySecretNameOverride) }}
+{{ if and (not (or .Values.ksoc.accessKeySecretNameOverride)) (or (and .Values.ksoc.base64AccessKeyId .Values.ksoc.base64SecretKey) .Values.ksoc.apiKey) }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
We cannot pass in api keys from the EKS Marketplace Addon to render the helm chart. The most straightforward thing we can do is omit the creation of it if base64AccessKeyId, base64SecretKey, and apiKey are empty. 

This PR changes the configuration of the secret to not render it if that condition is not met. 
