### PR TITLE
Bump plugins versions

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.2.12
+version: 1.2.13
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -16,9 +16,11 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
+    - kind: security
+      description: Dependencies update.
     - kind: fixed
-      description: Removes unused Falco plugins.
-  artifacthub.io/containsSecurityUpdates: "false"
+      description: Change default sbom format to cyclonedx-json.
+  artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: source
       url: https://github.com/ksoclabs/ksoc-plugins-helm-chart

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -129,7 +129,7 @@ Example output (chart version may differ):
 ```bash
 helm search repo ksoc
 NAME                     	CHART VERSION	APP VERSION	DESCRIPTION
-ksoc/ksoc-plugins        	1.2.7        	           	A Helm chart to run the KSOC plugins
+ksoc/ksoc-plugins        	1.2.13        	           	A Helm chart to run the KSOC plugins
 ```
 
 ### 4. Create cluster-specific values file

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -22,7 +22,7 @@ ksocBootstrapper:
   image:
     # -- The image to use for the ksoc-bootstrapper deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-bootstrapper).
     repository: us.gcr.io/ksoc-public/ksoc-bootstrapper
-    tag: v1.1.3
+    tag: v1.1.4
   env: {}
   resources:
     limits:
@@ -40,7 +40,7 @@ ksocGuard:
   image:
     # -- The image to use for the ksoc-guard deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-guard).
     repository: us.gcr.io/ksoc-public/ksoc-guard
-    tag: v1.1.4
+    tag: v1.1.5
   config:
     # -- Whether to block on error.
     BLOCK_ON_ERROR: false
@@ -72,7 +72,7 @@ ksocRuntime:
   reporter:
     image:
       repository: us.gcr.io/ksoc-public/runtime-reporter
-      tag: v1.1.3
+      tag: v1.1.4
     env:
       LOG_LEVEL: info
     resources:
@@ -161,7 +161,7 @@ ksocSbom:
   image:
     # -- The image to use for the ksoc-sbom deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-sbom).
     repository: us.gcr.io/ksoc-public/ksoc-sbom
-    tag: v1.1.10
+    tag: v1.1.11
   env:
     # -- Whether to mutate the image in pod spec by adding digest at the end. By default, digests are added to images to ensure
     # that the image that runs in the cluster matches the digest of the build.  Disable this if your continuous deployment
@@ -188,7 +188,7 @@ ksocSync:
   image:
     # -- The image to use for the ksoc-sync deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-sync).
     repository: us.gcr.io/ksoc-public/ksoc-sync
-    tag: v1.1.3
+    tag: v1.1.4
   env: {}
   resources:
     limits:
@@ -206,7 +206,7 @@ ksocWatch:
   image:
     # -- The image to use for the ksoc-watch deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-watch).
     repository: us.gcr.io/ksoc-public/ksoc-watch
-    tag: v1.1.14
+    tag: v1.1.15
   env:
     # -- Whether to trigger reconciliation at startup.
     RECONCILIATION_AT_START: false


### PR DESCRIPTION
#### What this PR does / why we need it

- Bumped dependencies to fix CVEs
- Bumped alpine version to 3.19.1
- Changed default sbom format to cyclonedx json 

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md](./stable/ksoc-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
