### PR TITLE
Adds empty deployment for EKS Marketplace Addon

### DIFF
--- a/.github/workflows/build-marketplace-helm-chart.yaml
+++ b/.github/workflows/build-marketplace-helm-chart.yaml
@@ -14,8 +14,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Replace Images and Remove Comments In values.yaml
-      run: ./scripts/replace_repositories.sh
+    - name: Modify Helm Chart For AWS Marketplace
+      run: ./scripts/modify_chart_for_aws_marketplace.sh
 
     - name: Install Helm
       uses: azure/setup-helm@v3

--- a/scripts/modify_chart_for_aws_marketplace.sh
+++ b/scripts/modify_chart_for_aws_marketplace.sh
@@ -3,11 +3,14 @@
 FILE="./stable/ksoc-plugins/values.yaml"
 
 GCR_REGISTRY_NAME="us.gcr.io/ksoc-public"
-
 FALCO_REGISTRY="docker.io/falcosecurity"
+ECR_PUBLIC_REGISTRY="public.ecr.aws/eks-distro/kubernetes"
 
 ECR_REGISTRY_NAME="709825985650.dkr.ecr.us-east-1.amazonaws.com/ksoc-labs"
 
+sed -i "s|$ECR_PUBLIC_REGISTRY|$ECR_REGISTRY_NAME|g" "$FILE"
 sed -i "s|$GCR_REGISTRY_NAME|$ECR_REGISTRY_NAME|g" "$FILE"
 sed -i "s|$FALCO_REGISTRY|$ECR_REGISTRY_NAME|g" "$FILE"
 sed -i '/# --/d' "$FILE"
+
+yq e -i '.eksAddon.enabled = true' $FILE

--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.2.14
+version: 1.2.15
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -16,8 +16,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Add explanation in the README.md file how to change the SBOM format
+    - kind: added
+      description: Adds EKS Marketplace Addon deployment to track installation status
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/templates/eks_addon_deployment.yaml
+++ b/stable/ksoc-plugins/templates/eks_addon_deployment.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.eksAddon.enabled  }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ksoc-eks-marketplace-deployment
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app_name: ksoc-eks-marketplace-deployment
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app_name: ksoc-eks-marketplace-deployment
+  template:
+    metadata:
+      labels:
+        app_name: ksoc-eks-marketplace-deployment
+    spec:
+      containers:
+      - name: pause
+        image: {{ .Values.eksAddon.image.repository }}:{{ .Values.eksAddon.image.tag }}
+{{- end }}

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -270,3 +270,12 @@ metacollector:
   resources: {}
   tolerations: []
   nodeSelector: {}
+
+# -- Configuration for the EKS Addon dummy deployment. This is needed to track the status of addon.
+# -- This is a known issue and this is the  workaround for now. If you are not installing through the
+# -- EKS Addon Marketplace, you do not need to enable the addon.
+eksAddon:
+  enabled: false
+  image:
+    repository: public.ecr.aws/eks-distro/kubernetes/pause
+    tag: v1.29.1-eks-1-29-latest


### PR DESCRIPTION
Towards ENG-1593

Adds an empty deployment for the EKS Marketplace Addon. We need to have a dummy deployment for the EKS Addon to be able to track the status of the deployment of the addon. This Deployment is only rendered when `eksAddon.enabled` is set to true. This should only get set in the replace_repository script before pushing to the AWS Marketplace. The script has a new name because it now does more than only replacing images. 
