### PR TITLE
Add k9 in-cluster response plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ CURRENT_WORKING_DIR=$(shell pwd)
 initialise:
 	pre-commit --version || brew install pre-commit
 	shellcheck --version || brew install shellcheck
+	helm-docs --version || brew install norwoodj/tap/helm-docs
 	pre-commit install
 	pre-commit run --all-files
 

--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.2.16
+version: 1.3.0
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -17,7 +17,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: added
-      description: Adds ephemeral-storage limits for all of the plugins
+      description: Add k9 in-cluster response plugin
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -56,6 +56,25 @@ ksocRuntime:
 
 When `ksoc-runtime` is enabled an additional deployment can be seen. There is also a `DaemonSet` that deploys an eBPF pod on each node to gather the run-time information.  For more information on the `ksoc-runtime` plugin, please see the [KSOC Runtime documentation](https://docs.ksoc.com/docs/ksoc-runtime-1).
 
+### k9 plugin
+`k9` is a plugin that responds in-cluster to commands from the Rad Security platform. The plugin will poll the Rad Security backend, and does not require any ingress to the cluster.  The plugin is not enabled by default. Individual capabilities must be opted-into by the user, and the plugin will only respond to commands that are explicitly enabled.  To enable a capability, please enable the plugin with `enabled: true` and set the capabilities you wish to enable to `true` in your values file.
+
+```yaml
+k9:
+  enabled: true
+  capabilities:
+    enableTerminatePod: true
+    enableTerminateNamespace: true
+    enableQuarantine: true
+    enableGetLogs: true
+    enableLabelPod: true
+```
+Terminate Pod: Allows the plugin to terminate a pod in the cluster.
+Terminate Namespace: Allows the plugin to terminate a namespace in the cluster.
+Quarantine: Allows the plugin to quarantine a pod in the cluster via a NetworkPolicy to prevent it from communicating over the network.
+Get Logs: Allows the plugin to retrieve logs from a pod in the cluster.
+Label Pod: Allows the plugin to label a pod in the cluster.
+
 ## Prerequisites
 
 The remainder of this page assumes the following:
@@ -338,7 +357,41 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| falco | object | `{"fullnameOverride":"ksoc-runtime-ds","image":{"falco":{"repository":"docker.io/falcosecurity/falco-no-driver","tag":"0.37.1"},"falcoctl":{"repository":"docker.io/falcosecurity/falcoctl","tag":"0.7.1"}},"resources":{"limits":{"cpu":"1","ephemeral-storage":"1Gi","memory":"1Gi"},"requests":{"cpu":"100m","ephemeral-storage":"100Mi","memory":"512Mi"}},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane"}]}` | You can change them if need be. |
+| falco.fullnameOverride | string | `"ksoc-runtime-ds"` |  |
+| falco.image.falco.repository | string | `"docker.io/falcosecurity/falco-no-driver"` |  |
+| falco.image.falco.tag | string | `"0.37.1"` |  |
+| falco.image.falcoctl.repository | string | `"docker.io/falcosecurity/falcoctl"` |  |
+| falco.image.falcoctl.tag | string | `"0.7.1"` |  |
+| falco.resources.limits.cpu | string | `"1"` |  |
+| falco.resources.limits.ephemeral-storage | string | `"1Gi"` |  |
+| falco.resources.limits.memory | string | `"1Gi"` |  |
+| falco.resources.requests.cpu | string | `"100m"` |  |
+| falco.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
+| falco.resources.requests.memory | string | `"512Mi"` |  |
+| falco.tolerations[0].effect | string | `"NoSchedule"` |  |
+| falco.tolerations[0].key | string | `"node-role.kubernetes.io/master"` |  |
+| falco.tolerations[1].effect | string | `"NoSchedule"` |  |
+| falco.tolerations[1].key | string | `"node-role.kubernetes.io/control-plane"` |  |
+| k9.backend.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-backend-agent"` |  |
+| k9.backend.image.tag | string | `"v0.0.23"` |  |
+| k9.capabilities.enableGetLogs | bool | `false` |  |
+| k9.capabilities.enableLabelPod | bool | `false` |  |
+| k9.capabilities.enableQuarantine | bool | `false` |  |
+| k9.capabilities.enableTerminateNamespace | bool | `false` |  |
+| k9.capabilities.enableTerminatePod | bool | `false` |  |
+| k9.enabled | bool | `false` |  |
+| k9.frontend.agentActionPollInterval | string | `"5s"` | The interval in which the agent polls the backend for new actions. |
+| k9.frontend.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-frontend-agent"` |  |
+| k9.frontend.image.tag | string | `"v0.0.23"` |  |
+| k9.nodeSelector | object | `{}` |  |
+| k9.replicas | int | `1` |  |
+| k9.resources.limits.cpu | string | `"250m"` |  |
+| k9.resources.limits.ephemeral-storage | string | `"1Gi"` |  |
+| k9.resources.limits.memory | string | `"512Mi"` |  |
+| k9.resources.requests.cpu | string | `"100m"` |  |
+| k9.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
+| k9.resources.requests.memory | string | `"128Mi"` |  |
+| k9.tolerations | list | `[]` |  |
 | ksoc.accessKeySecretNameOverride | string | `""` | The name of the custom secret containing Access Key. |
 | ksoc.apiKey | string | `""` | The combined API key to authenticate with KSOC |
 | ksoc.apiUrl | string | `"https://api.ksoc.com"` | The base URL for the KSOC API. |
@@ -437,6 +490,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocWatch.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | ksocWatch.resources.requests.memory | string | `"128Mi"` |  |
 | ksocWatch.tolerations | list | `[]` |  |
-| metacollector | object | `{"enabled":false,"image":{"repository":"docker.io/falcosecurity/k8s-metacollector","tag":"0.1.0"},"nodeSelector":{},"resources":{},"tolerations":[]}` | ksoc-runtime is enabled and metacollector is set to be enabled. |
+| metacollector.enabled | bool | `false` |  |
+| metacollector.image.repository | string | `"docker.io/falcosecurity/k8s-metacollector"` |  |
+| metacollector.image.tag | string | `"0.1.0"` |  |
+| metacollector.nodeSelector | object | `{}` |  |
+| metacollector.resources | object | `{}` |  |
+| metacollector.tolerations | list | `[]` |  |
 | workloads.disableServiceMesh | bool | `true` | Whether to disable service mesh integration. |
 | workloads.imagePullSecretName | string | `""` | The image pull secret name to use to pull container images. |

--- a/stable/ksoc-plugins/README.md.gotmpl
+++ b/stable/ksoc-plugins/README.md.gotmpl
@@ -56,6 +56,25 @@ ksocRuntime:
 
 When `ksoc-runtime` is enabled an additional deployment can be seen. There is also a `DaemonSet` that deploys an eBPF pod on each node to gather the run-time information.  For more information on the `ksoc-runtime` plugin, please see the [KSOC Runtime documentation](https://docs.ksoc.com/docs/ksoc-runtime-1).
 
+### k9 plugin
+`k9` is a plugin that responds in-cluster to commands from the Rad Security platform. The plugin will poll the Rad Security backend, and does not require any ingress to the cluster.  The plugin is not enabled by default. Individual capabilities must be opted-into by the user, and the plugin will only respond to commands that are explicitly enabled.  To enable a capability, please enable the plugin with `enabled: true` and set the capabilities you wish to enable to `true` in your values file.
+
+```yaml
+k9:
+  enabled: true
+  capabilities:
+    enableTerminatePod: true
+    enableTerminateNamespace: true
+    enableQuarantine: true
+    enableGetLogs: true
+    enableLabelPod: true
+```
+Terminate Pod: Allows the plugin to terminate a pod in the cluster.
+Terminate Namespace: Allows the plugin to terminate a namespace in the cluster.
+Quarantine: Allows the plugin to quarantine a pod in the cluster via a NetworkPolicy to prevent it from communicating over the network.
+Get Logs: Allows the plugin to retrieve logs from a pod in the cluster.
+Label Pod: Allows the plugin to label a pod in the cluster.
+
 ## Prerequisites
 
 The remainder of this page assumes the following:

--- a/stable/ksoc-plugins/templates/ksoc-k9/deployment.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-k9/deployment.yaml
@@ -1,0 +1,158 @@
+{{- if .Values.k9.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ksoc-k9
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app_name: ksoc-k9
+    maintained_by: ksoc
+spec:
+  minReadySeconds: 90
+  replicas: {{ .Values.k9.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: ksoc-k9
+  template:
+    metadata:
+      labels:
+        app: ksoc-k9
+        maintained_by: ksoc
+      annotations:
+        {{- if .Values.workloads.disableServiceMesh }}
+        linkerd.io/inject: disabled
+        sidecar.istio.io/inject: "false"
+        {{- end }}
+    spec:
+      serviceAccountName: agent-ksoc-k9
+      {{- if .Values.workloads.imagePullSecretName }}
+      imagePullSecrets:
+        - name: {{ .Values.workloads.imagePullSecretName }}
+      {{- end }}
+      initContainers:
+{{ include "ksoc-plugins.bootstrap-initcontainer" . | indent 8 }}
+      containers:
+      - name: agent-be
+        image: "{{.Values.k9.backend.image.repository}}:{{.Values.k9.backend.image.tag}}"
+        imagePullPolicy: IfNotPresent
+        resources:
+{{ toYaml .Values.k9.resources | indent 10 }}
+        env:
+          - name: AGENT_DEPLOYMENT_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: AGENT_DEPLOYMENT_NAMESPACE
+            value: {{ .Release.Namespace }}
+          {{- if .Values.k9.capabilities.enableTerminatePod }}
+          - name: ENABLE_TERMINATE_POD
+            value: "true"
+          {{- end }}
+          {{- if .Values.k9.capabilities.enableTerminateNamespace }}
+          - name: ENABLE_TERMINATE_NAMESPACE
+            value: "true"
+          {{- end }}
+          {{- if .Values.k9.capabilities.enableQuarantine }}
+          - name: ENABLE_QUARANTINE
+            value: "true"
+          {{- end }}
+          {{- if .Values.k9.capabilities.enableGetLogs }}
+          - name: ENABLE_GET_LOGS
+            value: "true"
+          {{- end }}
+          {{- if .Values.k9.capabilities.enableLabelPod }}
+          - name: ENABLE_LABEL_POD
+            value: "true"
+          {{- end }}
+        volumeMounts:
+          - name: shared
+            mountPath: /shared
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: api-token
+            readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+      - name: agent-fe
+        image: "{{.Values.k9.frontend.image.repository}}:{{.Values.k9.frontend.image.tag}}"
+        imagePullPolicy: IfNotPresent
+        resources:
+{{ toYaml .Values.k9.resources | indent 10 }}
+        env:
+          - name: KSOC_API_URL
+            value: {{ .Values.ksoc.apiUrl }}
+          - name: KSOC_NAMESPACE
+            value: {{ .Release.Namespace }}
+{{ include "ksoc-plugins.access-key-env-secret" . | indent 10 }}
+          - name: AGENT_ACTION_POLL_INTERVAL
+            value: {{ .Values.k9.frontend.agentActionPollInterval }}
+          - name: AGENT_DEPLOYMENT_NAMESPACE
+            value: {{ .Release.Namespace }}
+          {{- if .Values.k9.capabilities.enableTerminatePod }}
+          - name: ENABLE_TERMINATE_POD
+            value: "true"
+          {{- end }}
+          {{- if .Values.k9.capabilities.enableTerminateNamespace }}
+          - name: ENABLE_TERMINATE_NAMESPACE
+            value: "true"
+          {{- end }}
+          {{- if .Values.k9.capabilities.enableQuarantine }}
+          - name: ENABLE_QUARANTINE
+            value: "true"
+          {{- end }}
+          {{- if .Values.k9.capabilities.enableGetLogs }}
+          - name: ENABLE_GET_LOGS
+            value: "true"
+          {{- end }}
+          {{- if .Values.k9.capabilities.enableLabelPod }}
+          - name: ENABLE_LABEL_POD
+            value: "true"
+          {{- end }}
+        volumeMounts:
+          - name: shared
+            mountPath: /shared
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: api-token
+            readOnly: true
+        livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8082
+            initialDelaySeconds: 15
+            periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8082
+          initialDelaySeconds: 5
+          periodSeconds: 10
+      volumes:
+      - name: shared
+        emptyDir:
+          sizeLimit: 10Mi
+      - name: api-token
+        secret:
+          secretName: ksoc-k9-api-token-secret
+      {{- with .Values.k9.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.k9.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+{{- end -}}

--- a/stable/ksoc-plugins/templates/ksoc-k9/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-k9/rbac.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.k9.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ksoc-k9-response
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "delete", "update"]
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"] ## TODO:: rahul :: watch is needed only for cm, later we can remove it.
+  verbs: ["get", "list", "create", "update", "watch"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+  verbs: ["get"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["networkpolicies"]
+  verbs: ["create", "update", "get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ksoc-k9-response
+subjects:
+- kind: ServiceAccount
+  name: agent-ksoc-k9
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: ksoc-k9-response
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ksoc-k9-kube-root-ca-reader
+  namespace: kube-system
+  labels:
+    app_name: ksoc-sbom
+    maintained_by: ksoc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ksoc-kube-root-ca-reader
+subjects:
+  - kind: ServiceAccount
+    name: agent-ksoc-k9
+    namespace: {{ .Release.Namespace }}
+
+{{- end -}}

--- a/stable/ksoc-plugins/templates/ksoc-k9/service-account.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-k9/service-account.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.k9.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent-ksoc-k9
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app_name: ksoc-k9
+    maintained_by: ksoc
+automountServiceAccountToken: false
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ksoc-k9-api-token-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app_name: ksoc-k9
+    maintained_by: ksoc
+  annotations:
+    kubernetes.io/service-account.name: agent-ksoc-k9
+type: kubernetes.io/service-account-token
+
+{{- end -}}

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -249,8 +249,8 @@ ksocWatch:
     allowlist: []
     denylist: []
 
-# -- Falco Daemonset configuration. The tolerations and resources are what are provided by default.
-# -- You can change them if need be.
+  # -- Falco Daemonset configuration. The tolerations and resources are what are provided by default.
+  # -- You can change them if need be.
 falco:
   image:
     falcoctl:
@@ -261,10 +261,10 @@ falco:
       tag: "0.37.1"
   fullnameOverride: ksoc-runtime-ds
   tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
   resources:
     limits:
       cpu: "1"
@@ -275,14 +275,48 @@ falco:
       memory: 512Mi
       ephemeral-storage: 100Mi
 
-# -- The Falco k8s-metacollector is disabled by default. It will only be created if
-# -- ksoc-runtime is enabled and metacollector is set to be enabled.
+  # -- The Falco k8s-metacollector is disabled by default. It will only be created if
+  # -- ksoc-runtime is enabled and metacollector is set to be enabled.
 metacollector:
   enabled: false
   image:
     repository: docker.io/falcosecurity/k8s-metacollector
     tag: 0.1.0
   resources: {}
+  tolerations: []
+  nodeSelector: {}
+
+  # -- K9 is an in-cluster response plugin.  It will request any queued commands from
+  # -- the Rad Security backend, and execute them in the cluster.  Each capability must
+  # -- be opted into individually.
+k9:
+  enabled: false
+  replicas: 1
+  frontend:
+    image:
+      repository: us.gcr.io/ksoc-public/ksoc-frontend-agent
+      tag: v0.0.23
+    # -- The interval in which the agent polls the backend for new actions.
+    agentActionPollInterval: "5s"
+  backend:
+    image:
+      repository: us.gcr.io/ksoc-public/ksoc-backend-agent
+      tag: v0.0.23
+  resources:
+    limits:
+      cpu: 250m
+      memory: 512Mi
+      ephemeral-storage: 1Gi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+      ephemeral-storage: 100Mi
+  capabilities:
+    enableTerminatePod: false
+    enableTerminateNamespace: false
+    enableQuarantine: false
+    enableGetLogs: false
+    enableLabelPod: false
   tolerations: []
   nodeSelector: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it
Add the `k9` plugin to respond to in-cluster commands issued by the Rad Security platform.  The k9 plugin will poll for any queued up commands and execute commands that have been enabled by the plugin, ignoring the others.

#### Special notes for your reviewer
N/A

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
