### PR TITLE
Add experimental ksoc-node-agent plugin

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.3.0
+version: 1.4.0
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -17,7 +17,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: added
-      description: Add k9 in-cluster response plugin
+      description: Add experimental ksoc-node-agent plugin
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -357,6 +357,9 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| eksAddon.enabled | bool | `false` |  |
+| eksAddon.image.repository | string | `"public.ecr.aws/eks-distro/kubernetes/pause"` |  |
+| eksAddon.image.tag | string | `"v1.29.1-eks-1-29-latest"` |  |
 | falco.fullnameOverride | string | `"ksoc-runtime-ds"` |  |
 | falco.image.falco.repository | string | `"docker.io/falcosecurity/falco-no-driver"` |  |
 | falco.image.falco.tag | string | `"0.37.1"` |  |
@@ -430,6 +433,25 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocGuard.tolerations | list | `[]` |  |
 | ksocGuard.webhook.objectSelector | object | `{}` |  |
 | ksocGuard.webhook.timeoutSeconds | int | `10` |  |
+| ksocNodeAgent.agent.env | object | `{}` |  |
+| ksocNodeAgent.agent.resources.limits.cpu | string | `"200m"` |  |
+| ksocNodeAgent.agent.resources.limits.ephemeral-storage | string | `"1Gi"` |  |
+| ksocNodeAgent.agent.resources.limits.memory | string | `"1Gi"` |  |
+| ksocNodeAgent.agent.resources.requests.cpu | string | `"100m"` |  |
+| ksocNodeAgent.agent.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
+| ksocNodeAgent.agent.resources.requests.memory | string | `"128Mi"` |  |
+| ksocNodeAgent.enabled | bool | `false` |  |
+| ksocNodeAgent.exporter.env | object | `{}` |  |
+| ksocNodeAgent.exporter.resources.limits.cpu | string | `"500m"` |  |
+| ksocNodeAgent.exporter.resources.limits.ephemeral-storage | string | `"1Gi"` |  |
+| ksocNodeAgent.exporter.resources.limits.memory | string | `"1Gi"` |  |
+| ksocNodeAgent.exporter.resources.requests.cpu | string | `"100m"` |  |
+| ksocNodeAgent.exporter.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
+| ksocNodeAgent.exporter.resources.requests.memory | string | `"128Mi"` |  |
+| ksocNodeAgent.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-node-agent"` |  |
+| ksocNodeAgent.image.tag | string | `"v0.0.7"` |  |
+| ksocNodeAgent.nodeSelector | object | `{}` |  |
+| ksocNodeAgent.tolerations | list | `[]` |  |
 | ksocRuntime.detectReachableVulnerabilities | bool | `false` |  |
 | ksocRuntime.enabled | bool | `false` |  |
 | ksocRuntime.reporter.env.LOG_LEVEL | string | `"info"` |  |

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
@@ -1,0 +1,225 @@
+{{- if .Values.ksocNodeAgent.enabled -}}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: ksoc-high-priority
+value: 1000000
+globalDefault: false
+description: "This priority class should be used for node agent only."
+
+---
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ksoc-node-agent
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app_name: ksoc-node-agent
+    app_version: {{ .Values.ksocNodeAgent.image.tag | quote }}
+    maintained_by: ksoc
+spec:
+  selector:
+    matchLabels:
+      app_name: ksoc-node-agent
+  template:
+    metadata:
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/agent: unconfined
+        prometheus.io/path: "/"
+        prometheus.io/scrape: "true"
+      labels:
+        app_name: ksoc-node-agent
+        app_version: {{ .Values.ksocNodeAgent.image.tag | quote }}
+        maintained_by: ksoc
+    spec:
+      {{- if .Values.workloads.imagePullSecretName }}
+      imagePullSecrets:
+        - name: {{ .Values.workloads.imagePullSecretName }}
+      {{- end }}
+      initContainers:
+{{ include "ksoc-plugins.bootstrap-initcontainer" . | indent 8 }}
+      containers:
+        - command:
+            - micro-agent
+          env:
+            - name: HOST_ROOT
+              value: /host
+            - name: AGENT_LOG_LEVEL
+              value: INFO
+            - name: AGENT_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: AGENT_TRACER_IGNORE_NAMESPACES
+              value: |
+                cert-manager,
+                ksoc,
+                kube-node-lease,
+                kube-public,
+                kube-system
+            - name: AGENT_TRACER_NET_IGNORE_HOST_NETWORK_NS
+              value: "1"
+            {{- range $key, $value := .Values.ksocNodeAgent.agent.env }}
+            - name: "{{ $key }}"
+              value: "{{ $value }}"
+            {{- end }}
+          image: {{ .Values.ksocNodeAgent.image.repository }}:{{ .Values.ksocNodeAgent.image.tag }}
+          imagePullPolicy: Always
+          name: agent
+          ports:
+            - containerPort: 8000
+          resources:
+{{ toYaml .Values.ksocNodeAgent.agent.resources | indent 12 }}
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+                - SYSLOG
+                - SYS_PTRACE
+                - SYS_RESOURCE
+                - IPC_LOCK
+                - NET_ADMIN
+                - NET_RAW
+              drop:
+                - ALL
+            privileged: false
+            runAsUser: 0
+            seLinuxOptions:
+              type: super_t
+          volumeMounts:
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: api-token
+              readOnly: true
+            - mountPath: /tmp
+              name: unix-socket
+            - mountPath: /host/bin
+              name: bin
+              readOnly: true
+            - mountPath: /host/etc
+              name: etc
+            - mountPath: /host/opt
+              name: opt
+            - mountPath: /host/usr
+              name: usr
+              readOnly: true
+            - mountPath: /host/run
+              name: run
+              readOnly: true
+            - mountPath: /host/proc
+              name: proc
+              readOnly: true
+            - mountPath: /run
+              name: run
+            - mountPath: /sys/kernel/debug
+              name: debugfs
+            - mountPath: /sys/kernel/tracing
+              name: tracefs
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+            - mountPath: /sys/fs/bpf
+              name: bpffs
+
+        - command:
+            - micro-exporter
+          env:
+            - name: EXPORTER_LOG_LEVEL
+              value: INFO
+            - name: EXPORTER_PROVIDER_STDOUT_ENABLED
+              value: "false"
+            - name: EXPORTER_PROVIDER_KSOC_API_ENABLED
+              value: "true"
+            - name: EXPORTER_PROVIDER_KSOC_API_URL
+              value: {{ .Values.ksoc.apiUrl }}
+            - name: EXPORTER_PROVIDER_KSOC_API_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: access-key-id
+                  name: ksoc-access-key
+            - name: EXPORTER_PROVIDER_KSOC_API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: secret-key
+                  name: ksoc-access-key
+            {{- range $key, $value := .Values.ksocNodeAgent.exporter.env }}
+            - name: "{{ $key }}"
+              value: "{{ $value }}"
+            {{- end }}
+          image: {{ .Values.ksocNodeAgent.image.repository }}:{{ .Values.ksocNodeAgent.image.tag }}
+          imagePullPolicy: Always
+          name: exporter
+          ports:
+            - containerPort: 8001
+          resources:
+{{ toYaml .Values.ksocNodeAgent.exporter.resources | indent 12 }}
+          volumeMounts:
+            - mountPath: /tmp
+              name: unix-socket
+
+      dnsPolicy: ClusterFirst
+      {{- with .Values.ksocNodeAgent.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+        {{- end }}
+      restartPolicy: Always
+      automountServiceAccountToken: false
+      serviceAccount: ksoc-node-agent
+      serviceAccountName: ksoc-node-agent
+      terminationGracePeriodSeconds: 30
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+      {{- with .Values.ksocNodeAgent.tolerations }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      volumes:
+        - name: api-token
+          secret:
+            secretName: ksoc-node-agent-api-token-secret
+        - name: unix-socket
+        - hostPath:
+            path: /bin
+            type: ""
+          name: bin
+        - hostPath:
+            path: /etc
+            type: ""
+          name: etc
+        - hostPath:
+            path: /opt
+            type: ""
+          name: opt
+        - hostPath:
+            path: /usr
+            type: ""
+          name: usr
+        - hostPath:
+            path: /proc
+            type: ""
+          name: proc
+        - hostPath:
+            path: /run
+            type: ""
+          name: run
+        - hostPath:
+            path: /sys/fs/cgroup
+            type: ""
+          name: cgroup
+        - hostPath:
+            path: /sys/fs/bpf
+            type: ""
+          name: bpffs
+        - hostPath:
+            path: /sys/kernel/debug
+            type: ""
+          name: debugfs
+        - hostPath:
+            path: /sys/kernel/tracing
+            type: ""
+          name: tracefs
+{{- end -}}

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/rbac.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.ksocNodeAgent.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ksoc-node-agent
+  namespace: ksoc
+  labels:
+    app_name: ksoc-node-agent
+    app_version: {{ .Values.ksocNodeAgent.image.tag | quote }}
+    maintained_by: ksoc
+automountServiceAccountToken: false
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ksoc-node-agent-api-token-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app_name: ksoc-node-agent
+    app_version: {{ .Values.ksocNodeAgent.image.tag | quote }}
+    maintained_by: ksoc
+  annotations:
+    kubernetes.io/service-account.name: ksoc-node-agent
+type: kubernetes.io/service-account-token
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ksoc-node-agent
+  labels:
+    app_name: ksoc-node-agent
+    app_version: {{ .Values.ksocNodeAgent.image.tag | quote }}
+    maintained_by: ksoc
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "watch", "list"]
+
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "watch", "list"]
+
+  - apiGroups: [ "" ]
+    resources: [ "nodes" ]
+    verbs: [ "get", "watch", "list" ]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ksoc-node-agent
+  labels:
+    app_name: ksoc-node-agent
+    app_version: {{ .Values.ksocNodeAgent.image.tag | quote }}
+    maintained_by: ksoc
+roleRef:
+  kind: ClusterRole
+  name: ksoc-node-agent
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: ksoc-node-agent
+    namespace: ksoc
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ksoc-now-agent-kube-root-ca-reader
+  namespace: kube-system
+  labels:
+    app_name: ksoc-node-agent
+    app_version: {{ .Values.ksocNodeAgent.image.tag | quote }}
+    maintained_by: ksoc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ksoc-kube-root-ca-reader
+subjects:
+  - kind: ServiceAccount
+    name: ksoc-node-agent
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -249,6 +249,36 @@ ksocWatch:
     allowlist: []
     denylist: []
 
+ksocNodeAgent:
+  enabled: false
+  image:
+    repository: us.gcr.io/ksoc-public/ksoc-node-agent
+    tag: v0.0.7
+  agent:
+    env: {}
+    resources:
+      limits:
+        cpu: 200m
+        memory: 1Gi
+        ephemeral-storage: 1Gi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+        ephemeral-storage: 100Mi
+  exporter:
+    env: {}
+    resources:
+      limits:
+        cpu: 500m
+        memory: 1Gi
+        ephemeral-storage: 1Gi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+        ephemeral-storage: 100Mi
+  nodeSelector: {}
+  tolerations: []
+
   # -- Falco Daemonset configuration. The tolerations and resources are what are provided by default.
   # -- You can change them if need be.
 falco:


### PR DESCRIPTION
#### What this PR does / why we need it
Add the `node-agent` enabling Runtime Insights capabalities by the Rad Security platform. 

#### Special notes for your reviewer
N/A

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated (we don't provide public docs for this experimental release yet)
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
