### PR TITLE
Improve node-agent check

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.4.1
+version: 1.4.2
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -16,8 +16,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: added
-      description: Resource limits for bootstrap initcontainer
+    - kind: changed
+      description: Improved conditional logic checking is node-agent is enabled
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -357,6 +357,9 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| eksAddon.enabled | bool | `false` |  |
+| eksAddon.image.repository | string | `"public.ecr.aws/eks-distro/kubernetes/pause"` |  |
+| eksAddon.image.tag | string | `"v1.29.1-eks-1-29-latest"` |  |
 | falco.fullnameOverride | string | `"ksoc-runtime-ds"` |  |
 | falco.image.falco.repository | string | `"docker.io/falcosecurity/falco-no-driver"` |  |
 | falco.image.falco.tag | string | `"0.37.1"` |  |

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ksocNodeAgent.enabled -}}
+{{- if and .Values.ksocNodeAgent .Values.ksocNodeAgent.enabled -}}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ksocNodeAgent.enabled -}}
+{{- if and .Values.ksocNodeAgent .Values.ksocNodeAgent.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
#### What this PR does / why we need it
Improved conditional logic checking if node-agent should be enabled for setups when `values.yaml` without `ksocNodeAgent` block are reused.

#### Special notes for your reviewer
N/A

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
