### PR TITLE
Add node-agent config for reachable vulnerabilities

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.4.4
+version: 1.4.5
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -17,7 +17,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: Added
-      description: Makes seccomp profiles toggleable
+      description: Add config option to enable reachable vulnerabilities using experimental ksoc-node-agent plugin
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -449,6 +449,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocNodeAgent.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-node-agent"` |  |
 | ksocNodeAgent.image.tag | string | `"v0.0.7"` |  |
 | ksocNodeAgent.nodeSelector | object | `{}` |  |
+| ksocNodeAgent.reachableVulnerabilitiesEnabled | bool | `false` |  |
 | ksocNodeAgent.tolerations | list | `[]` |  |
 | ksocRuntime.detectReachableVulnerabilities | bool | `false` |  |
 | ksocRuntime.enabled | bool | `false` |  |

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
@@ -60,7 +60,13 @@ spec:
                 kube-public,
                 kube-system
             - name: AGENT_TRACER_NET_IGNORE_HOST_NETWORK_NS
-              value: "1"
+              value: "true"
+            {{- if .Values.ksocNodeAgent.reachableVulnerabilitiesEnabled }}
+            - name: AGENT_TRACER_OPEN_ENABLED
+              value: "true"
+            - name: AGENT_TRACER_OPEN_PREFIXES
+              value: "/lib,/lib64,/usr,/bin,/sbin"
+            {{- end }}
             {{- range $key, $value := .Values.ksocNodeAgent.agent.env }}
             - name: "{{ $key }}"
               value: "{{ $value }}"

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -254,6 +254,7 @@ ksocWatch:
 
 ksocNodeAgent:
   enabled: false
+  reachableVulnerabilitiesEnabled: false
   image:
     repository: us.gcr.io/ksoc-public/ksoc-node-agent
     tag: v0.0.7


### PR DESCRIPTION
#### What this PR does / why we need it
Add a config option enabling `node-agent` to track open events required to support reachable vulnerabilities.

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated (we don't provide public docs for this experimental release yet)
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
