### PR TITLE
Fix CI by bumping kubernetes-toolkit image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    container: us.gcr.io/ksoc-public/kubernetes-toolkit:1.24.9
+    container: us.gcr.io/ksoc-public/kubernetes-toolkit:1.29.4
     steps:
       - name: clone repo
         uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    container: us.gcr.io/ksoc-public/kubernetes-toolkit:1.24.9
+    container: us.gcr.io/ksoc-public/kubernetes-toolkit:1.29.4
     steps:
       - name: clone repo
         uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    container: us.gcr.io/ksoc-public/kubernetes-toolkit:1.24.9
+    container: us.gcr.io/ksoc-public/kubernetes-toolkit:1.29.4
     steps:
       - name: clone repo
         uses: actions/checkout@v4

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    container: us.gcr.io/ksoc-public/kubernetes-toolkit:1.24.9
+    container: us.gcr.io/ksoc-public/kubernetes-toolkit:1.29.4
     steps:
       - name: clone repo
         uses: actions/checkout@v4


### PR DESCRIPTION
#### What this PR does / why we need it
We had an issue where CI was failing due to old `helm-docs` package used in `kubernetes-toolkit` image used in CI

