### PR TITLE
Add access key secret override to Node Agent manifest

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.4.7
+version: 1.4.8
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -16,8 +16,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: Added
-      description: Node agent - configure container collectors
+    - kind: added
+      description: Node agent - added support for access key secret override
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
@@ -164,13 +164,21 @@ spec:
             - name: EXPORTER_PROVIDER_KSOC_API_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  key: access-key-id
+                  {{ if .Values.ksoc.accessKeySecretNameOverride -}}
+                  name: {{ .Values.ksoc.accessKeySecretNameOverride }}
+                  {{ else -}}
                   name: ksoc-access-key
+                  {{ end -}}
+                  key: access-key-id
             - name: EXPORTER_PROVIDER_KSOC_API_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  key: secret-key
+                  {{ if .Values.ksoc.accessKeySecretNameOverride -}}
+                  name: {{ .Values.ksoc.accessKeySecretNameOverride }}
+                  {{ else -}}
                   name: ksoc-access-key
+                  {{ end -}}
+                  key: secret-key
             {{- range $key, $value := .Values.ksocNodeAgent.exporter.env }}
             - name: "{{ $key }}"
               value: "{{ $value }}"


### PR DESCRIPTION
#### What this PR does / why we need it
This allows to use `secretyKeyOverride` for Node Agent.

