### PR TITLE
Enable node agent log levels to be configured

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.4.8
+version: 1.4.9
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -17,7 +17,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: added
-      description: Node agent - added support for access key secret override
+      description: Node agent - added support for log level configuration
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -436,7 +436,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocNodeAgent.agent.collectors.docker.enabled | bool | `false` |  |
 | ksocNodeAgent.agent.collectors.docker.socket | string | `"run/docker.sock"` |  |
 | ksocNodeAgent.agent.collectors.runtimePath | string | `""` |  |
-| ksocNodeAgent.agent.env | object | `{}` |  |
+| ksocNodeAgent.agent.env.AGENT_LOG_LEVEL | string | `"INFO"` |  |
 | ksocNodeAgent.agent.hostPID | bool | `false` |  |
 | ksocNodeAgent.agent.mounts.volumeMounts | list | `[]` |  |
 | ksocNodeAgent.agent.mounts.volumes | list | `[]` |  |
@@ -447,7 +447,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocNodeAgent.agent.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | ksocNodeAgent.agent.resources.requests.memory | string | `"128Mi"` |  |
 | ksocNodeAgent.enabled | bool | `false` |  |
-| ksocNodeAgent.exporter.env | object | `{}` |  |
+| ksocNodeAgent.exporter.env.EXPORTER_LOG_LEVEL | string | `"INFO"` |  |
 | ksocNodeAgent.exporter.resources.limits.cpu | string | `"500m"` |  |
 | ksocNodeAgent.exporter.resources.limits.ephemeral-storage | string | `"1Gi"` |  |
 | ksocNodeAgent.exporter.resources.limits.memory | string | `"1Gi"` |  |

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
@@ -64,8 +64,6 @@ spec:
               value: {{ .runtimePath | quote }}
             {{- end }}
             {{- end }}
-            - name: AGENT_LOG_LEVEL
-              value: INFO
             - name: AGENT_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -153,8 +151,6 @@ spec:
         - command:
             - micro-exporter
           env:
-            - name: EXPORTER_LOG_LEVEL
-              value: INFO
             - name: EXPORTER_PROVIDER_STDOUT_ENABLED
               value: "false"
             - name: EXPORTER_PROVIDER_KSOC_API_ENABLED

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -259,7 +259,8 @@ ksocNodeAgent:
     repository: us.gcr.io/ksoc-public/ksoc-node-agent
     tag: v0.0.8
   agent:
-    env: {}
+    env:
+      AGENT_LOG_LEVEL: INFO
     resources:
       limits:
         cpu: 200m
@@ -286,7 +287,8 @@ ksocNodeAgent:
       volumeMounts: []
 
   exporter:
-    env: {}
+    env:
+      EXPORTER_LOG_LEVEL: INFO
     resources:
       limits:
         cpu: 500m


### PR DESCRIPTION
#### What this PR does / why we need it
Allow node agent log levels to be configured.

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
