### PR TITLE
Enable configuration of ignored namespaces by node agent

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.4.9
+version: 1.4.10
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -17,7 +17,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: added
-      description: Node agent - added support for log level configuration
+      description: Node agent - added support for namespace monitoring configuration
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -437,6 +437,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocNodeAgent.agent.collectors.docker.socket | string | `"run/docker.sock"` |  |
 | ksocNodeAgent.agent.collectors.runtimePath | string | `""` |  |
 | ksocNodeAgent.agent.env.AGENT_LOG_LEVEL | string | `"INFO"` |  |
+| ksocNodeAgent.agent.env.AGENT_TRACER_IGNORE_NAMESPACES | string | `"cert-manager,\nksoc,\nkube-node-lease,\nkube-public,\nkube-system\n"` |  |
 | ksocNodeAgent.agent.hostPID | bool | `false` |  |
 | ksocNodeAgent.agent.mounts.volumeMounts | list | `[]` |  |
 | ksocNodeAgent.agent.mounts.volumes | list | `[]` |  |

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
@@ -71,13 +71,6 @@ spec:
                   fieldPath: spec.nodeName
             - name: AGENT_TRACER_AUTO_MOUNT_FILESYSTEMS
               value: "1"
-            - name: AGENT_TRACER_IGNORE_NAMESPACES
-              value: |
-                cert-manager,
-                ksoc,
-                kube-node-lease,
-                kube-public,
-                kube-system
             - name: AGENT_TRACER_NET_IGNORE_HOST_NETWORK_NS
               value: "true"
             {{- if .Values.ksocNodeAgent.reachableVulnerabilitiesEnabled }}

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -261,6 +261,12 @@ ksocNodeAgent:
   agent:
     env:
       AGENT_LOG_LEVEL: INFO
+      AGENT_TRACER_IGNORE_NAMESPACES: |
+        cert-manager,
+        ksoc,
+        kube-node-lease,
+        kube-public,
+        kube-system
     resources:
       limits:
         cpu: 200m


### PR DESCRIPTION
#### What this PR does / why we need it
To allow the new node agent to be rolled out more incrementally, we want to allow namespaces that the node agent will ignore to be configurable by users, and will therefore promote the hard-coded `AGENT_TRACER_IGNORE_NAMESPACES` environment variable to the values.yaml file.

#### Special notes for your reviewer
N/A

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
