### PR TITLE
node-agent: allow changing event queue size and grpc server batch size values

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.4.10
+version: 1.4.11
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -17,7 +17,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: added
-      description: Node agent - added support for namespace monitoring configuration
+      description: Node agent - added support for queue size and grpc server batch size configuration
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -434,10 +434,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocNodeAgent.agent.collectors.containerd.enabled | bool | `true` |  |
 | ksocNodeAgent.agent.collectors.containerd.socket | string | `"/run/containerd/containerd.sock"` |  |
 | ksocNodeAgent.agent.collectors.docker.enabled | bool | `false` |  |
-| ksocNodeAgent.agent.collectors.docker.socket | string | `"run/docker.sock"` |  |
+| ksocNodeAgent.agent.collectors.docker.socket | string | `"/run/docker.sock"` |  |
 | ksocNodeAgent.agent.collectors.runtimePath | string | `""` |  |
 | ksocNodeAgent.agent.env.AGENT_LOG_LEVEL | string | `"INFO"` |  |
 | ksocNodeAgent.agent.env.AGENT_TRACER_IGNORE_NAMESPACES | string | `"cert-manager,\nksoc,\nkube-node-lease,\nkube-public,\nkube-system\n"` |  |
+| ksocNodeAgent.agent.eventQueueSize | int | `4096` |  |
+| ksocNodeAgent.agent.grpcServerBatchSize | int | `50` |  |
 | ksocNodeAgent.agent.hostPID | bool | `false` |  |
 | ksocNodeAgent.agent.mounts.volumeMounts | list | `[]` |  |
 | ksocNodeAgent.agent.mounts.volumes | list | `[]` |  |

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
@@ -79,6 +79,14 @@ spec:
             - name: AGENT_TRACER_OPEN_PREFIXES
               value: "/lib,/lib64,/usr,/bin,/sbin"
             {{- end }}
+            {{- if .Values.ksocNodeAgent.agent.eventQueueSize }}
+            - name: AGENT_EVENT_QUEUE_SIZE
+              value: {{ .Values.ksocNodeAgent.agent.eventQueueSize | quote }}
+            {{- end }}
+            {{- if .Values.ksocNodeAgent.agent.grpcServerBatchSize }}
+            - name: AGENT_GRPC_SERVER_BATCH_SIZE
+              value: {{ .Values.ksocNodeAgent.agent.grpcServerBatchSize | quote }}
+            {{- end }}
             {{- range $key, $value := .Values.ksocNodeAgent.agent.env }}
             - name: "{{ $key }}"
               value: "{{ $value }}"

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -282,7 +282,7 @@ ksocNodeAgent:
       runtimePath: ""
       docker:
         enabled: false
-        socket: run/docker.sock
+        socket: /run/docker.sock
       containerd:
         enabled: true
         socket: /run/containerd/containerd.sock
@@ -291,7 +291,8 @@ ksocNodeAgent:
       volumes: []
       # A list of volume mounts you want to add to the agent pods.
       volumeMounts: []
-
+    eventQueueSize: 4096
+    grpcServerBatchSize: 50
   exporter:
     env:
       EXPORTER_LOG_LEVEL: INFO


### PR DESCRIPTION
#### What this PR does / why we need it

Make event queue size and grpc server batch size configurable via values.yml.

#### Special notes for your reviewer

/

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
