### PR TITLE
make more clear the name of ksoc-sbom mutating webhook

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.4.16
+version: 1.4.17
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -16,8 +16,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: fixed
-      description: KSOC sbom - cleanup cache after calculating sbom
+    - kind: added
+      description: KSOC SBOM - make more clear the name of ksoc-sbom mutating webhook
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/templates/ksoc-sbom/mutating-webhook-config.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-sbom/mutating-webhook-config.yaml
@@ -3,7 +3,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: mutating-webhook-configuration
+  name: ksoc-sbom
   namespace: {{ .Release.Namespace }}
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/ksoc-sbom # needs to be cert name!


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This updates the name of the mutating webhook for ksoc-sbom, making it more clear what we're looking at when listing them and matching the pattern implemented by ksoc-guard

#### Special notes for your reviewer
Thank you for the quick review!

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
