### PR TITLE
Expose nodeName field in node-agent pod spec

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.4.13
+version: 1.4.14
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -17,7 +17,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: added
-      description: KSOC runtime - added user-configurable PriorityClass
+      description: KSOC runtime - expose nodeName field in pod spec
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -459,6 +459,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocNodeAgent.exporter.resources.requests.memory | string | `"128Mi"` |  |
 | ksocNodeAgent.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-node-agent"` |  |
 | ksocNodeAgent.image.tag | string | `"v0.0.8"` |  |
+| ksocNodeAgent.nodeName | string | `""` |  |
 | ksocNodeAgent.nodeSelector | object | `{}` |  |
 | ksocNodeAgent.reachableVulnerabilitiesEnabled | bool | `false` |  |
 | ksocNodeAgent.tolerations | list | `[]` |  |

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
@@ -192,6 +192,9 @@ spec:
               name: unix-socket
 
       dnsPolicy: ClusterFirst
+      {{ if .Values.ksocNodeAgent.nodeName -}}
+      nodeName: {{ .Values.ksocNodeAgent.nodeName }}
+      {{ end -}}
       {{- with .Values.ksocNodeAgent.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -314,6 +314,7 @@ ksocNodeAgent:
         memory: 128Mi
         ephemeral-storage: 100Mi
   nodeSelector: {}
+  nodeName: ""
   tolerations: []
 
   # -- Falco Daemonset configuration. The tolerations and resources are what are provided by default.


### PR DESCRIPTION
#### What this PR does / why we need it
Expose `nodeName` in the ksoc-node-agent pod spec to enable more granular control over deploys.

#### Special notes for your reviewer
N/A

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
