### PR TITLE
Expose updateStrategy for node agent DaemonSet

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.4.18
+version: 1.4.19
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -17,7 +17,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: KSOC Node Agent - improved API export performance
+      description: KSOC Node Agent - expose updateStrategy in DaemonSet template
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -463,6 +463,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocNodeAgent.nodeSelector | object | `{}` |  |
 | ksocNodeAgent.reachableVulnerabilitiesEnabled | bool | `false` |  |
 | ksocNodeAgent.tolerations | list | `[]` |  |
+| ksocNodeAgent.updateStrategy.rollingUpdate.maxSurge | string | `"0"` | The maximum number of pods that can be scheduled above the desired number of pods. Can be an absolute number ("5") or percent, e.g. "10%" |
+| ksocNodeAgent.updateStrategy.rollingUpdate.maxUnavailable | string | `"1"` | The maximum number of pods that can be unavailable during the update. Can be an absolute number ("5") or percent, e.g. "10%" |
+| ksocNodeAgent.updateStrategy.type | string | `"RollingUpdate"` |  |
 | ksocRuntime.detectReachableVulnerabilities | bool | `false` |  |
 | ksocRuntime.enabled | bool | `false` |  |
 | ksocRuntime.reporter.env.LOG_LEVEL | string | `"info"` |  |

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
@@ -22,6 +22,8 @@ spec:
   selector:
     matchLabels:
       app_name: ksoc-node-agent
+  updateStrategy:
+{{ toYaml .Values.ksocNodeAgent.updateStrategy | indent 4 }}
   template:
     metadata:
       annotations:

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -318,6 +318,13 @@ ksocNodeAgent:
   nodeSelector: {}
   nodeName: ""
   tolerations: []
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # -- The maximum number of pods that can be unavailable during the update. Can be an absolute number ("5") or percent, e.g. "10%"
+      maxUnavailable: "1"
+      # -- The maximum number of pods that can be scheduled above the desired number of pods. Can be an absolute number ("5") or percent, e.g. "10%"
+      maxSurge: "0"
 
   # -- Falco Daemonset configuration. The tolerations and resources are what are provided by default.
   # -- You can change them if need be.


### PR DESCRIPTION
#### What this PR does / why we need it
Enable end users to control the node agent DaemonSet update strategy, e.g. set `maxUnavailable` to `"50%"`.

#### Special notes for your reviewer
N/A

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
