### PR TITLE
Moves kube-system rbac resources to a seperate file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.4.0
+          version: v3.14.2
       - uses: actions/setup-python@v4
         with:
           python-version: 3.7

--- a/scripts/modify_chart_for_aws_marketplace.sh
+++ b/scripts/modify_chart_for_aws_marketplace.sh
@@ -14,3 +14,6 @@ sed -i "s|$FALCO_REGISTRY|$ECR_REGISTRY_NAME|g" "$FILE"
 sed -i '/# --/d' "$FILE"
 
 yq e -i '.eksAddon.enabled = true' $FILE
+
+rm ./stable/ksoc-plugins/templates/access-key-secret.yaml
+rm ./stable/ksoc-plugins/templates/rbac-kube-system.yaml

--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.4.21
+version: 1.4.22
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -16,8 +16,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: fixed
-      description: KSOC Node Agent - Log level alignment across dependencies
+    - kind: changed
+      description: Moved RBAC resources that were created in kube-system namespace to a seperate file
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/templates/ksoc-guard/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-guard/rbac.yaml
@@ -110,26 +110,6 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: ksoc-guard-kube-root-ca-reader
-  namespace: kube-system
-  labels:
-    app_name: ksoc-guard
-    app_version: {{ .Values.ksocGuard.image.tag | quote }}
-    maintained_by: ksoc
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: ksoc-kube-root-ca-reader
-subjects:
-  - kind: ServiceAccount
-    name: ksoc-guard
-    namespace: {{ .Release.Namespace }}
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
   name: ksoc-guard-leader-election
   namespace: {{ .Release.Namespace }}
   labels:

--- a/stable/ksoc-plugins/templates/ksoc-k9/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-k9/rbac.yaml
@@ -33,21 +33,4 @@ roleRef:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: ksoc-k9-kube-root-ca-reader
-  namespace: kube-system
-  labels:
-    app_name: ksoc-sbom
-    maintained_by: ksoc
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: ksoc-kube-root-ca-reader
-subjects:
-  - kind: ServiceAccount
-    name: agent-ksoc-k9
-    namespace: {{ .Release.Namespace }}
-
 {{- end -}}

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/rbac.yaml
@@ -67,23 +67,4 @@ subjects:
     name: ksoc-node-agent
     namespace: ksoc
 
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: ksoc-now-agent-kube-root-ca-reader
-  namespace: kube-system
-  labels:
-    app_name: ksoc-node-agent
-    app_version: {{ .Values.ksocNodeAgent.image.tag | quote }}
-    maintained_by: ksoc
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: ksoc-kube-root-ca-reader
-subjects:
-  - kind: ServiceAccount
-    name: ksoc-node-agent
-    namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/ksoc-plugins/templates/ksoc-sbom/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-sbom/rbac.yaml
@@ -104,26 +104,6 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: ksoc-sbom-kube-root-ca-reader
-  namespace: kube-system
-  labels:
-    app_name: ksoc-sbom
-    app_version: {{ .Values.ksocSbom.image.tag | quote }}
-    maintained_by: ksoc
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: ksoc-kube-root-ca-reader
-subjects:
-  - kind: ServiceAccount
-    name: ksoc-sbom
-    namespace: {{ .Release.Namespace }}
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
   name: ksoc-sbom-leader-election
   namespace: {{ .Release.Namespace }}
   labels:

--- a/stable/ksoc-plugins/templates/ksoc-sync/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-sync/rbac.yaml
@@ -96,23 +96,4 @@ subjects:
     name: ksoc-sync
     namespace: {{ .Release.Namespace }}
 
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: ksoc-sync-kube-root-ca-reader
-  namespace: kube-system
-  labels:
-    app_name: ksoc-sync
-    app_version: {{ .Values.ksocSync.image.tag | quote }}
-    maintained_by: ksoc
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: ksoc-kube-root-ca-reader
-subjects:
-  - kind: ServiceAccount
-    name: ksoc-sync
-    namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/ksoc-plugins/templates/ksoc-watch/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-watch/rbac.yaml
@@ -131,23 +131,4 @@ subjects:
     name: ksoc-watch
     namespace: {{ .Release.Namespace }}
 
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: ksoc-watch-kube-root-ca-reader
-  namespace: kube-system
-  labels:
-    app_name: ksoc-watch
-    app_version: {{ .Values.ksocWatch.image.tag | quote }}
-    maintained_by: ksoc
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: ksoc-kube-root-ca-reader
-subjects:
-  - kind: ServiceAccount
-    name: ksoc-watch
-    namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/ksoc-plugins/templates/rbac-kube-system.yaml
+++ b/stable/ksoc-plugins/templates/rbac-kube-system.yaml
@@ -1,0 +1,140 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ksoc-kube-root-ca-reader
+  namespace: kube-system
+  labels:
+    maintained_by: ksoc
+rules:
+  - apiGroups: [""]
+    resources: [ "configmaps" ]
+    resourceNames: [ "kube-root-ca.crt" ]
+    verbs: ["get", "watch", "list"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ksoc-guard-kube-root-ca-reader
+  namespace: kube-system
+  labels:
+    app_name: ksoc-guard
+    app_version: {{ .Values.ksocGuard.image.tag | quote }}
+    maintained_by: ksoc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ksoc-kube-root-ca-reader
+subjects:
+  - kind: ServiceAccount
+    name: ksoc-guard
+    namespace: {{ .Release.Namespace }}
+
+---
+{{- if and .Values.k9 .Values.k9.enabled -}}
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ksoc-k9-kube-root-ca-reader
+  namespace: kube-system
+  labels:
+    app_name: ksoc-sbom
+    maintained_by: ksoc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ksoc-kube-root-ca-reader
+subjects:
+  - kind: ServiceAccount
+    name: agent-ksoc-k9
+    namespace: {{ .Release.Namespace }}
+
+---
+{{- end -}}
+
+{{- if and .Values.ksocNodeAgent .Values.ksocNodeAgent.enabled -}}
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ksoc-now-agent-kube-root-ca-reader
+  namespace: kube-system
+  labels:
+    app_name: ksoc-node-agent
+    app_version: {{ .Values.ksocNodeAgent.image.tag | quote }}
+    maintained_by: ksoc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ksoc-kube-root-ca-reader
+subjects:
+  - kind: ServiceAccount
+    name: ksoc-node-agent
+    namespace: {{ .Release.Namespace }}
+
+---
+{{- end -}}
+
+{{- if .Values.ksocSbom.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ksoc-sbom-kube-root-ca-reader
+  namespace: kube-system
+  labels:
+    app_name: ksoc-sbom
+    app_version: {{ .Values.ksocSbom.image.tag | quote }}
+    maintained_by: ksoc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ksoc-kube-root-ca-reader
+subjects:
+  - kind: ServiceAccount
+    name: ksoc-sbom
+    namespace: {{ .Release.Namespace }}
+---
+{{- end -}}
+
+{{- if .Values.ksocSync.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ksoc-sync-kube-root-ca-reader
+  namespace: kube-system
+  labels:
+    app_name: ksoc-sync
+    app_version: {{ .Values.ksocSync.image.tag | quote }}
+    maintained_by: ksoc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ksoc-kube-root-ca-reader
+subjects:
+  - kind: ServiceAccount
+    name: ksoc-sync
+    namespace: {{ .Release.Namespace }}
+---
+{{- end -}}
+
+{{- if .Values.ksocWatch.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ksoc-watch-kube-root-ca-reader
+  namespace: kube-system
+  labels:
+    app_name: ksoc-watch
+    app_version: {{ .Values.ksocWatch.image.tag | quote }}
+    maintained_by: ksoc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ksoc-kube-root-ca-reader
+subjects:
+  - kind: ServiceAccount
+    name: ksoc-watch
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/ksoc-plugins/templates/rbac-kube-system.yaml
+++ b/stable/ksoc-plugins/templates/rbac-kube-system.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -11,8 +12,8 @@ rules:
     resourceNames: [ "kube-root-ca.crt" ]
     verbs: ["get", "watch", "list"]
 
+{{- if .Values.ksocGuard.enabled }}
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -30,10 +31,10 @@ subjects:
   - kind: ServiceAccount
     name: ksoc-guard
     namespace: {{ .Release.Namespace }}
+{{- end }}
 
+{{- if and .Values.k9 .Values.k9.enabled }}
 ---
-{{- if and .Values.k9 .Values.k9.enabled -}}
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -50,12 +51,10 @@ subjects:
   - kind: ServiceAccount
     name: agent-ksoc-k9
     namespace: {{ .Release.Namespace }}
-
----
 {{- end -}}
 
-{{- if and .Values.ksocNodeAgent .Values.ksocNodeAgent.enabled -}}
-
+{{- if and .Values.ksocNodeAgent .Values.ksocNodeAgent.enabled }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -73,11 +72,10 @@ subjects:
   - kind: ServiceAccount
     name: ksoc-node-agent
     namespace: {{ .Release.Namespace }}
-
----
 {{- end -}}
 
-{{- if .Values.ksocSbom.enabled -}}
+{{- if .Values.ksocSbom.enabled }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -95,10 +93,10 @@ subjects:
   - kind: ServiceAccount
     name: ksoc-sbom
     namespace: {{ .Release.Namespace }}
----
-{{- end -}}
+{{- end }}
 
-{{- if .Values.ksocSync.enabled -}}
+{{- if .Values.ksocSync.enabled }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -116,10 +114,10 @@ subjects:
   - kind: ServiceAccount
     name: ksoc-sync
     namespace: {{ .Release.Namespace }}
----
-{{- end -}}
+{{- end }}
 
-{{- if .Values.ksocWatch.enabled -}}
+{{- if .Values.ksocWatch.enabled }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -137,4 +135,4 @@ subjects:
   - kind: ServiceAccount
     name: ksoc-watch
     namespace: {{ .Release.Namespace }}
-{{- end -}}
+{{- end }}

--- a/stable/ksoc-plugins/templates/rbac.yaml
+++ b/stable/ksoc-plugins/templates/rbac.yaml
@@ -1,21 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: ksoc-kube-root-ca-reader
-  namespace: kube-system
-  labels:
-    maintained_by: ksoc
-rules:
-  - apiGroups: [""]
-    resources: [ "configmaps" ]
-    resourceNames: [ "kube-root-ca.crt" ]
-    verbs: ["get", "watch", "list"]
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
   name: ksoc-leader-election-role
   namespace: {{ .Release.Namespace }}
   labels:


### PR DESCRIPTION
Towards ENG-1760

In the EKS Marketplace, we cannot create Kubernetes resources outside of the ksoc namespace. To accommodate for this, we can put them in a separate file, remove it when we are creating the helm chart for EKS Marketplace, and then add it to our documentation to explain how to add the necessary permissions to be able to add the needed RBAC permissions.

I tested this by installing the plugins on a kind cluster normally. Once that worked, I removed the rbac-kube-system.yaml file, installed the helm chart, and then applied the resources in rbac-kube-system.yaml . This resulted in all of our pods running without issue. 