### PR TITLE
Fix default UpdateStrategy for Node Agent

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.4.22
+version: 1.4.23
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -16,8 +16,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: changed
-      description: Moved RBAC resources that were created in kube-system namespace to a seperate file
+    - kind: fixed
+      description: Fixed default UpdateStrategy for Node Agent
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -463,8 +463,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocNodeAgent.nodeSelector | object | `{}` |  |
 | ksocNodeAgent.reachableVulnerabilitiesEnabled | bool | `false` |  |
 | ksocNodeAgent.tolerations | list | `[]` |  |
-| ksocNodeAgent.updateStrategy.rollingUpdate.maxSurge | string | `"0"` | The maximum number of pods that can be scheduled above the desired number of pods. Can be an absolute number ("5") or percent, e.g. "10%" |
-| ksocNodeAgent.updateStrategy.rollingUpdate.maxUnavailable | string | `"1"` | The maximum number of pods that can be unavailable during the update. Can be an absolute number ("5") or percent, e.g. "10%" |
+| ksocNodeAgent.updateStrategy.rollingUpdate.maxSurge | int | `0` | The maximum number of pods that can be scheduled above the desired number of pods. Can be an absolute number or percent, e.g. `5` or `"10%"` |
+| ksocNodeAgent.updateStrategy.rollingUpdate.maxUnavailable | int | `1` | The maximum number of pods that can be unavailable during the update. Can be an absolute number or percent, e.g.  `5` or `"10%"` |
 | ksocNodeAgent.updateStrategy.type | string | `"RollingUpdate"` |  |
 | ksocRuntime.detectReachableVulnerabilities | bool | `false` |  |
 | ksocRuntime.enabled | bool | `false` |  |

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -321,10 +321,10 @@ ksocNodeAgent:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      # -- The maximum number of pods that can be unavailable during the update. Can be an absolute number ("5") or percent, e.g. "10%"
-      maxUnavailable: "1"
-      # -- The maximum number of pods that can be scheduled above the desired number of pods. Can be an absolute number ("5") or percent, e.g. "10%"
-      maxSurge: "0"
+      # -- The maximum number of pods that can be unavailable during the update. Can be an absolute number or percent, e.g.  `5` or `"10%"`
+      maxUnavailable: 1
+      # -- The maximum number of pods that can be scheduled above the desired number of pods. Can be an absolute number or percent, e.g. `5` or `"10%"`
+      maxSurge: 0
 
   # -- Falco Daemonset configuration. The tolerations and resources are what are provided by default.
   # -- You can change them if need be.


### PR DESCRIPTION
#### What this PR does / why we need it
This fixes the default `values.yaml` config for Node Agent's `UpdateStrategy`. It should be [int or string](https://github.com/kubernetes/kubernetes/blob/bce55b94cdc3a4592749aa919c591fa7df7453eb/pkg/apis/apps/types.go#L618). When it's a string, it has to be a percent value, e.g., `50%`.

#### Special notes for your reviewer
N/A

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
