### PR TITLE
Fixes yaml seperators in plugins

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.4.27
+version: 1.4.28
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -16,8 +16,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: changed
-      description: Moved RBAC for kube-system resources back into RBAC definitions for the individual services
+    - kind: fixed
+      description: Fixed bug in conditional for RBAC role assignment for reading the root CA cert of the cluster
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/templates/ksoc-k9/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-k9/rbac.yaml
@@ -52,5 +52,6 @@ subjects:
     namespace: ksoc
 
 ---
-{{- end -}}
-{{- end -}}
+
+{{- end }}
+{{- end }}

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/rbac.yaml
@@ -89,6 +89,6 @@ subjects:
     namespace: ksoc
 
 ---
-{{- end -}}
 
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/stable/ksoc-plugins/templates/ksoc-runtime/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-runtime/rbac.yaml
@@ -27,6 +27,8 @@ type: kubernetes.io/service-account-token
 
 ---
 
+{{ if ( eq .Values.eksAddon.enabled false ) -}}
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -45,4 +47,7 @@ subjects:
     name: ksoc-runtime
     namespace: {{ .Release.Namespace }}
 
-{{- end -}}
+---
+
+{{- end }}
+{{- end }}

--- a/stable/ksoc-plugins/templates/ksoc-sbom/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-sbom/rbac.yaml
@@ -159,5 +159,6 @@ subjects:
     namespace: {{ .Release.Namespace }}
 
 ---
-{{ end -}}
-{{ end -}}
+
+{{- end }}
+{{- end }}

--- a/stable/ksoc-plugins/templates/ksoc-sync/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-sync/rbac.yaml
@@ -117,5 +117,6 @@ subjects:
     namespace: {{ .Release.Namespace }}
 
 ---
-{{ end -}}
-{{ end -}}
+
+{{- end }}
+{{- end }}

--- a/stable/ksoc-plugins/templates/ksoc-watch/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-watch/rbac.yaml
@@ -152,5 +152,6 @@ subjects:
     namespace: {{ .Release.Namespace }}
 
 ---
-{{ end -}}
-{{ end -}}
+
+{{- end }}
+{{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to ksoclabs/ksoc-plugins-helm-chart.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

#### Special notes for your reviewer

#### Checklist

- [X] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [X] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated
- [X] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated

There is a typo in how the Helm templating block for k9. Also some of the other resources had different dashes in different places. This PR corrects them and standardizes them. I enabled k9 by default to test it and put it into dry-run to confirm. This was the output.

```
helm template stable/ksoc-plugins | kubectl apply -f - --dry-run=client
serviceaccount/ksoc-guard created (dry run)
serviceaccount/agent-ksoc-k9 created (dry run)
serviceaccount/ksoc-sbom created (dry run)
serviceaccount/ksoc-sync created (dry run)
serviceaccount/ksoc-watch created (dry run)
secret/ksoc-guard-api-token-secret created (dry run)
secret/ksoc-k9-api-token-secret created (dry run)
secret/ksoc-sbom-api-token-secret created (dry run)
secret/ksoc-sync-api-token-secret created (dry run)
secret/ksoc-watch-api-token-secret created (dry run)
configmap/ksoc-guard-dynamic-configuration created (dry run)
configmap/ksoc-sbom-dynamic-configuration created (dry run)
configmap/ksoc-sync-dynamic-configuration created (dry run)
configmap/ksoc-watch-dynamic-configuration created (dry run)
clusterrole.rbac.authorization.k8s.io/ksoc-guard created (dry run)
clusterrole.rbac.authorization.k8s.io/ksoc-k9-response created (dry run)
clusterrole.rbac.authorization.k8s.io/ksoc-sbom created (dry run)
clusterrole.rbac.authorization.k8s.io/ksoc-sync created (dry run)
clusterrole.rbac.authorization.k8s.io/ksoc-watch created (dry run)
clusterrole.rbac.authorization.k8s.io/ksoc-proxy-role created (dry run)
clusterrolebinding.rbac.authorization.k8s.io/ksoc-guard created (dry run)
clusterrolebinding.rbac.authorization.k8s.io/ksoc-guard-proxy created (dry run)
clusterrolebinding.rbac.authorization.k8s.io/ksoc-k9-response created (dry run)
clusterrolebinding.rbac.authorization.k8s.io/ksoc-sbom created (dry run)
clusterrolebinding.rbac.authorization.k8s.io/ksoc-sbom-proxy created (dry run)
clusterrolebinding.rbac.authorization.k8s.io/ksoc-sync created (dry run)
clusterrolebinding.rbac.authorization.k8s.io/ksoc-watch created (dry run)
role.rbac.authorization.k8s.io/ksoc-guard-configmap-reader created (dry run)
role.rbac.authorization.k8s.io/ksoc-sbom-configmap-reader created (dry run)
role.rbac.authorization.k8s.io/ksoc-sync-configmap-mutator created (dry run)
role.rbac.authorization.k8s.io/ksoc-watch-configmap-reader created (dry run)
role.rbac.authorization.k8s.io/ksoc-leader-election-role created (dry run)
role.rbac.authorization.k8s.io/ksoc-kube-root-ca-reader created (dry run)
rolebinding.rbac.authorization.k8s.io/ksoc-guard-configmap-reader created (dry run)
rolebinding.rbac.authorization.k8s.io/ksoc-guard-leader-election created (dry run)
rolebinding.rbac.authorization.k8s.io/ksoc-guard-kube-root-ca-reader created (dry run)
rolebinding.rbac.authorization.k8s.io/ksoc-k9-kube-root-ca-reader created (dry run)
rolebinding.rbac.authorization.k8s.io/ksoc-sbom-configmap-reader created (dry run)
rolebinding.rbac.authorization.k8s.io/ksoc-sbom-leader-election created (dry run)
rolebinding.rbac.authorization.k8s.io/ksoc-sbom-kube-root-ca-reader created (dry run)
rolebinding.rbac.authorization.k8s.io/ksoc-sync-configmap-mutator created (dry run)
rolebinding.rbac.authorization.k8s.io/ksoc-sync-kube-root-ca-reader created (dry run)
rolebinding.rbac.authorization.k8s.io/ksoc-watch-configmap-reader created (dry run)
rolebinding.rbac.authorization.k8s.io/ksoc-watch-kube-root-ca-reader created (dry run)
service/ksoc-guard created (dry run)
service/ksoc-sbom created (dry run)
deployment.apps/ksoc-guard created (dry run)
deployment.apps/ksoc-k9 created (dry run)
deployment.apps/ksoc-sbom created (dry run)
deployment.apps/ksoc-sync created (dry run)
deployment.apps/ksoc-watch created (dry run)
mutatingwebhookconfiguration.admissionregistration.k8s.io/ksoc-guard created (dry run)
mutatingwebhookconfiguration.admissionregistration.k8s.io/ksoc-sbom created (dry run)
validatingwebhookconfiguration.admissionregistration.k8s.io/ksoc-guard created (dry run)
resource mapping not found for name: "ksoc-guard" namespace: "default" from "STDIN": no matches for kind "Certificate" in version "cert-manager.io/v1"
ensure CRDs are installed first
resource mapping not found for name: "ksoc-sbom" namespace: "default" from "STDIN": no matches for kind "Certificate" in version "cert-manager.io/v1"
ensure CRDs are installed first
resource mapping not found for name: "ksoc-selfsigned-issuer" namespace: "default" from "STDIN": no matches for kind "Issuer" in version "cert-manager.io/v1"
ensure CRDs are installed first
```

