### PR TITLE
Fix helm lint bug with rbac whitespace

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.4.28
+version: 1.4.29
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -17,7 +17,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fixed bug in conditional for RBAC role assignment for reading the root CA cert of the cluster
+      description: Fixed linter bug with trailing whitespace in RBAC files
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -159,7 +159,7 @@ Example output (chart version may differ):
 ```bash
 helm search repo ksoc
 NAME                     	CHART VERSION	APP VERSION	DESCRIPTION
-ksoc/ksoc-plugins        	1.4.24        	           	A Helm chart to run the KSOC plugins
+ksoc/ksoc-plugins        	1.4.29        	           	A Helm chart to run the KSOC plugins
 ```
 
 ### 4. Create cluster-specific values file

--- a/stable/ksoc-plugins/README.md.gotmpl
+++ b/stable/ksoc-plugins/README.md.gotmpl
@@ -159,7 +159,7 @@ Example output (chart version may differ):
 ```bash
 helm search repo ksoc
 NAME                     	CHART VERSION	APP VERSION	DESCRIPTION
-ksoc/ksoc-plugins        	1.4.24        	           	A Helm chart to run the KSOC plugins
+ksoc/ksoc-plugins        	1.4.29        	           	A Helm chart to run the KSOC plugins
 ```
 
 ### 4. Create cluster-specific values file

--- a/stable/ksoc-plugins/templates/ksoc-k9/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-k9/rbac.yaml
@@ -33,7 +33,7 @@ roleRef:
 
 ---
 
-{{- if ( eq .Values.eksAddon.enabled false ) -}}
+{{- if ( eq .Values.eksAddon.enabled false ) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/rbac.yaml
@@ -69,7 +69,7 @@ subjects:
 
 ---
 
-{{- if ( eq .Values.eksAddon.enabled false ) -}}
+{{- if ( eq .Values.eksAddon.enabled false ) }}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/stable/ksoc-plugins/templates/ksoc-runtime/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-runtime/rbac.yaml
@@ -27,7 +27,7 @@ type: kubernetes.io/service-account-token
 
 ---
 
-{{ if ( eq .Values.eksAddon.enabled false ) -}}
+{{ if ( eq .Values.eksAddon.enabled false ) }}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/stable/ksoc-plugins/templates/ksoc-sbom/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-sbom/rbac.yaml
@@ -140,7 +140,7 @@ subjects:
 
 ---
 
-{{ if ( eq .Values.eksAddon.enabled false ) -}}
+{{ if ( eq .Values.eksAddon.enabled false ) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/stable/ksoc-plugins/templates/ksoc-watch/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-watch/rbac.yaml
@@ -133,7 +133,7 @@ subjects:
 
 ---
 
-{{ if ( eq .Values.eksAddon.enabled false ) -}}
+{{ if ( eq .Values.eksAddon.enabled false ) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:


### PR DESCRIPTION
#### What this PR does / why we need it
Fix `helm lint`, which has rules that differ from `helm template`.

Before:
```
➜ helm lint stable/ksoc-plugins
==> Linting stable/ksoc-plugins
[ERROR] templates/ksoc-k9/rbac.yaml: unable to parse YAML: invalid Yaml document separator: apiVersion: rbac.authorization.k8s.io/v1

Error: 1 chart(s) linted, 1 chart(s) failed
```

After:
```
➜ helm lint stable/ksoc-plugins                     
==> Linting stable/ksoc-plugins

1 chart(s) linted, 0 chart(s) failed
```

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
