### PR TITLE
Add helm lint step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,3 +62,5 @@ jobs:
         uses: helm/chart-testing-action@v2.6.1
       - name: Run chart-testing (lint)
         run: ct lint --config test/ct.yaml
+      - name: Run helm lint
+        run: helm lint stable/ksoc-plugins


### PR DESCRIPTION
#### What this PR does / why we need it
Add an explicit `helm lint` CI step.  The existing chart-testing-action uses `yamllint`, which uses different rules than `helm lint`.  Some customers use `helm lint` in their own CI pipelines, and will fail on steps that `yamllint` and `helm template` treat as well-formed YAML.

See https://github.com/ksoclabs/ksoc-plugins-helm-chart/pull/164 for an example of something that passed the YAMLlint check, but was blocking customers using `helm lint`.

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
