### PR TITLE
Ensure that plugin service accounts obey Chart release namespace directive

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.5.4
+version: 1.5.5
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -17,7 +17,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fix the issue with the ksoc-sbom admission handler
+      description: Ensure plugin RBAC follows Chart release namespace directive
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/templates/ksoc-guard/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-guard/rbac.yaml
@@ -162,7 +162,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ksoc-guard
-    namespace: ksoc
+    namespace: {{ .Release.Namespace }}
 
 ---
 {{- end }}

--- a/stable/ksoc-plugins/templates/ksoc-k9/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-k9/rbac.yaml
@@ -49,7 +49,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: agent-ksoc-k9
-    namespace: ksoc
+    namespace: {{ .Release.Namespace }}
 
 ---
 

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/rbac.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ksoc-node-agent
-  namespace: ksoc
+  namespace: {{ .Release.Namespace }}
   labels:
     app_name: ksoc-node-agent
     app_version: {{ .Values.ksocNodeAgent.image.tag | quote }}
@@ -65,7 +65,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ksoc-node-agent
-    namespace: ksoc
+    namespace: {{ .Release.Namespace }}
 
 ---
 
@@ -86,7 +86,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ksoc-node-agent
-    namespace: ksoc
+    namespace: {{ .Release.Namespace }}
 
 ---
 


### PR DESCRIPTION
#### What this PR does / why we need it
Ensure that plugin service accounts obey Chart release namespace directive

#### Special notes for your reviewer
N/A

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
