### PR TITLE
Add exec filters allowing to redact command line arguments

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -16,8 +16,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: security
-      description: address security vulnerabilities
+    - kind: added
+      description: Added Node Agent Exec Filters to redact command line arguments
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.5.9
+version: 1.6.0
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -306,6 +306,45 @@ ksocWatch:
       - "ResourceC"
 ```
 
+## Node Agent Exec Filters
+
+Node Agent allows to use wildcard rules to filtering command line arguments
+
+To redact a secret used in `command secret=value`, you can use
+the following Node Agent configuration:
+
+```yaml
+ksocNodeAgent:
+  exporter:
+    execFilters:
+    - wildcard: "command secret=(*)"`.
+```
+
+All _wildcard groups_, i.e., `*` enclosed in parentheses will be redacted.
+
+Wildcards not enclosed in parentheses can be used to match arguments that should not be redacted.
+
+For example, the wildcard rule:
+```yaml
+ksocNodeAgent:
+  exporter:
+    execFilters:
+    - wildcard: "command * secret=(*)"
+```
+
+result in the following redacted commands:
+
+- `command -p secret=value` - `command -p secret=*****`
+- `command --some-param secret=value` - `command --some-param secret=*****`
+
+Simple patterns matching all commands can be also used. To redact `secret=value` in all commands, the following filter can be used:
+```yaml
+ksocNodeAgent:
+  exporter:
+    execFilters:
+    - wildcard: "secret=(*)"
+```
+
 ## Upgrading the Chart
 
 Typically, we advise maintaining the most current versions of plugins. However, our [KSOC](https://ksoc.com) plugins are designed to support upgrades between any two versions, with certain exceptions as outlined in our Helm chart changelog which you can access [here](https://artifacthub.io/packages/helm/ksoc/ksoc-plugins?modal=changelog).
@@ -436,6 +475,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocNodeAgent.agent.resources.requests.memory | string | `"128Mi"` |  |
 | ksocNodeAgent.enabled | bool | `false` |  |
 | ksocNodeAgent.exporter.env.EXPORTER_LOG_LEVEL | string | `"INFO"` |  |
+| ksocNodeAgent.exporter.execFilters | list | `[]` | Allows to specify wildcard rules for filtering command arguments. |
 | ksocNodeAgent.exporter.resources.limits.cpu | string | `"500m"` |  |
 | ksocNodeAgent.exporter.resources.limits.ephemeral-storage | string | `"1Gi"` |  |
 | ksocNodeAgent.exporter.resources.limits.memory | string | `"1Gi"` |  |
@@ -443,7 +483,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocNodeAgent.exporter.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | ksocNodeAgent.exporter.resources.requests.memory | string | `"128Mi"` |  |
 | ksocNodeAgent.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-node-agent"` |  |
-| ksocNodeAgent.image.tag | string | `"v0.0.17"` |  |
+| ksocNodeAgent.image.tag | string | `"v0.0.18"` |  |
 | ksocNodeAgent.nodeName | string | `""` |  |
 | ksocNodeAgent.nodeSelector | object | `{}` |  |
 | ksocNodeAgent.reachableVulnerabilitiesEnabled | bool | `false` |  |

--- a/stable/ksoc-plugins/README.md.gotmpl
+++ b/stable/ksoc-plugins/README.md.gotmpl
@@ -306,6 +306,46 @@ ksocWatch:
       - "ResourceC"
 ```
 
+## Node Agent Exec Filters
+
+
+Node Agent allows to use wildcard rules to filtering command line arguments
+
+To redact a secret used in `command secret=value`, you can use
+the following Node Agent configuration:
+
+```yaml
+ksocNodeAgent:
+  exporter:
+    execFilters:
+    - wildcard: "command secret=(*)"`.
+```
+
+All _wildcard groups_, i.e., `*` enclosed in parentheses will be redacted.
+
+Wildcards not enclosed in parentheses can be used to match arguments that should not be redacted.
+
+For example, the wildcard rule:
+```yaml
+ksocNodeAgent:
+  exporter:
+    execFilters:
+    - wildcard: "command * secret=(*)"
+```
+
+result in the following redacted commands:
+
+- `command -p secret=value` - `command -p secret=*****`
+- `command --some-param secret=value` - `command --some-param secret=*****`
+
+Simple patterns matching all commands can be also used. To redact `secret=value` in all commands, the following filter can be used:
+```yaml
+ksocNodeAgent:
+  exporter:
+    execFilters:
+    - wildcard: "secret=(*)"
+```
+
 ## Upgrading the Chart
 
 Typically, we advise maintaining the most current versions of plugins. However, our [KSOC](https://ksoc.com) plugins are designed to support upgrades between any two versions, with certain exceptions as outlined in our Helm chart changelog which you can access [here](https://artifacthub.io/packages/helm/ksoc/ksoc-plugins?modal=changelog).

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
@@ -178,6 +178,11 @@ spec:
                   name: ksoc-access-key
                   {{ end -}}
                   key: secret-key
+            {{ if .Values.ksocNodeAgent.exporter.execFilters -}}
+            {{- $filters := printf "execFilters: %s" (.Values.ksocNodeAgent.exporter.execFilters | toJson ) -}}
+            - name: EXPORTER_EXEC_FILTERS
+              value: {{  $filters | fromYaml | toJson | squote }}
+            {{- end }}
             {{- range $key, $value := .Values.ksocNodeAgent.exporter.env }}
             - name: "{{ $key }}"
               value: "{{ $value }}"

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -176,7 +176,7 @@ ksocNodeAgent:
   reachableVulnerabilitiesEnabled: false
   image:
     repository: us.gcr.io/ksoc-public/ksoc-node-agent
-    tag: v0.0.17
+    tag: v0.0.18
   agent:
     env:
       AGENT_LOG_LEVEL: INFO
@@ -215,6 +215,10 @@ ksocNodeAgent:
   exporter:
     env:
       EXPORTER_LOG_LEVEL: INFO
+
+    # -- Allows to specify wildcard rules for filtering command arguments.
+    execFilters: []
+
     resources:
       limits:
         cpu: 500m


### PR DESCRIPTION
#### What this PR does / why we need it
Add exec filters allowing to redact command line arguments like secrets and passwords before sending to the RAD API

#### Special notes for your reviewer
N/A

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
