### PR TITLE
Allow configuration of Service Accounts annotations

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.6.4
+version: 1.6.5
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -17,7 +17,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: added
-      description: Bumped ksoc-sbom plugin to improve performance
+      description: Allows ServiceAccount annotations to be set
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -417,6 +417,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | k9.resources.requests.cpu | string | `"100m"` |  |
 | k9.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | k9.resources.requests.memory | string | `"128Mi"` |  |
+| k9.serviceAccountAnnotations | object | `{}` |  |
 | k9.tolerations | list | `[]` |  |
 | ksoc.accessKeySecretNameOverride | string | `""` | The name of the custom secret containing Access Key. |
 | ksoc.apiKey | string | `""` | The combined API key to authenticate with KSOC |
@@ -454,6 +455,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocGuard.resources.requests.cpu | string | `"100m"` |  |
 | ksocGuard.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | ksocGuard.resources.requests.memory | string | `"100Mi"` |  |
+| ksocGuard.serviceAccountAnnotations | object | `{}` |  |
 | ksocGuard.tolerations | list | `[]` |  |
 | ksocGuard.webhook.objectSelector | object | `{}` |  |
 | ksocGuard.webhook.timeoutSeconds | int | `10` |  |
@@ -489,6 +491,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocNodeAgent.nodeName | string | `""` |  |
 | ksocNodeAgent.nodeSelector | object | `{}` |  |
 | ksocNodeAgent.reachableVulnerabilitiesEnabled | bool | `false` |  |
+| ksocNodeAgent.serviceAccountAnnotations | object | `{}` |  |
 | ksocNodeAgent.tolerations | list | `[]` |  |
 | ksocNodeAgent.updateStrategy.rollingUpdate.maxSurge | int | `0` | The maximum number of pods that can be scheduled above the desired number of pods. Can be an absolute number or percent, e.g. `5` or `"10%"` |
 | ksocNodeAgent.updateStrategy.rollingUpdate.maxUnavailable | int | `1` | The maximum number of pods that can be unavailable during the update. Can be an absolute number or percent, e.g.  `5` or `"10%"` |
@@ -523,6 +526,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocSync.resources.requests.cpu | string | `"100m"` |  |
 | ksocSync.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | ksocSync.resources.requests.memory | string | `"128Mi"` |  |
+| ksocSync.serviceAccountAnnotations | object | `{}` |  |
 | ksocSync.tolerations | list | `[]` |  |
 | ksocWatch.customResourceRules | object | `{"allowlist":[],"denylist":[]}` | Rules for Custom Resource ingestion containing allow- and denylists of rules specifying `apiGroups` and `resources`. E.g. `allowlist: apiGroups: ["custom.com"], resources: ["someResource", "otherResoure"]` Wildcards (`*`) can be used to match all. `customResourceRules.denylist` sets resources that should not be ingested. It has a priority over `customResourceRules.allowlist` to  deny resources allowed using a wildcard (`*`) match.  E.g. you can use `allowlist: apiGroups: ["custom.com"], resources: ["*"], denylist: apiGroups: ["custom.com"], resources: "excluded"` to ingest all resources within `custom.com` group but `excluded`. |
 | ksocWatch.enabled | bool | `true` |  |
@@ -538,6 +542,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocWatch.resources.requests.cpu | string | `"100m"` |  |
 | ksocWatch.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | ksocWatch.resources.requests.memory | string | `"128Mi"` |  |
+| ksocWatch.serviceAccountAnnotations | object | `{}` |  |
 | ksocWatch.tolerations | list | `[]` |  |
 | openshift.enabled | bool | `false` |  |
 | priorityClass.description | string | `"The priority class for KSOC components"` |  |

--- a/stable/ksoc-plugins/templates/ksoc-guard/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-guard/rbac.yaml
@@ -8,6 +8,10 @@ metadata:
     app_name: ksoc-guard
     app_version: {{ .Values.ksocGuard.image.tag | quote }}
     maintained_by: ksoc
+  annotations:
+    {{- with .Values.ksocGuard.serviceAccountAnnotations }}
+{{ toYaml . | indent 4 }}
+    {{- end }}
 automountServiceAccountToken: false
 
 ---

--- a/stable/ksoc-plugins/templates/ksoc-guard/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-guard/rbac.yaml
@@ -8,10 +8,10 @@ metadata:
     app_name: ksoc-guard
     app_version: {{ .Values.ksocGuard.image.tag | quote }}
     maintained_by: ksoc
+  {{- with .Values.ksocGuard.serviceAccountAnnotations }}
   annotations:
-    {{- with .Values.ksocGuard.serviceAccountAnnotations }}
 {{ toYaml . | indent 4 }}
-    {{- end }}
+  {{- end }}
 automountServiceAccountToken: false
 
 ---

--- a/stable/ksoc-plugins/templates/ksoc-k9/service-account.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-k9/service-account.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     app_name: ksoc-k9
     maintained_by: ksoc
+  {{- with .Values.k9.serviceAccountAnnotations }}
   annotations:
-    {{- with .Values.k9.serviceAccountAnnotations }}
 {{ toYaml . | indent 4 }}
-    {{- end }}
+  {{- end }}
 automountServiceAccountToken: false
 
 ---

--- a/stable/ksoc-plugins/templates/ksoc-k9/service-account.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-k9/service-account.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     app_name: ksoc-k9
     maintained_by: ksoc
+  annotations:
+    {{- with .Values.k9.serviceAccountAnnotations }}
+{{ toYaml . | indent 4 }}
+    {{- end }}
 automountServiceAccountToken: false
 
 ---

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/rbac.yaml
@@ -8,10 +8,10 @@ metadata:
     app_name: ksoc-node-agent
     app_version: {{ .Values.ksocNodeAgent.image.tag | quote }}
     maintained_by: ksoc
+  {{- with .Values.ksocNodeAgent.serviceAccountAnnotations }}
   annotations:
-    {{- with .Values.ksocNodeAgent.serviceAccountAnnotations }}
 {{ toYaml . | indent 4 }}
-    {{- end }}
+  {{- end }}
 automountServiceAccountToken: false
 
 ---

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/rbac.yaml
@@ -8,6 +8,10 @@ metadata:
     app_name: ksoc-node-agent
     app_version: {{ .Values.ksocNodeAgent.image.tag | quote }}
     maintained_by: ksoc
+  annotations:
+    {{- with .Values.ksocNodeAgent.serviceAccountAnnotations }}
+{{ toYaml . | indent 4 }}
+    {{- end }}
 automountServiceAccountToken: false
 
 ---

--- a/stable/ksoc-plugins/templates/ksoc-sbom/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-sbom/rbac.yaml
@@ -8,10 +8,10 @@ metadata:
     app_name: ksoc-sbom
     app_version: {{ .Values.ksocSbom.image.tag | quote }}
     maintained_by: ksoc
+  {{- with .Values.ksocSbom.serviceAccountAnnotations }}
   annotations:
-    {{- with .Values.ksocSbom.serviceAccountAnnotations }}
 {{ toYaml . | indent 4 }}
-    {{- end }}
+  {{- end }}
 automountServiceAccountToken: false
 
 ---

--- a/stable/ksoc-plugins/templates/ksoc-sbom/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-sbom/rbac.yaml
@@ -8,9 +8,9 @@ metadata:
     app_name: ksoc-sbom
     app_version: {{ .Values.ksocSbom.image.tag | quote }}
     maintained_by: ksoc
-    annotations:
+  annotations:
     {{- with .Values.ksocSbom.serviceAccountAnnotations }}
-{{ toYaml . | indent 6 }}
+{{ toYaml . | indent 4 }}
     {{- end }}
 automountServiceAccountToken: false
 

--- a/stable/ksoc-plugins/templates/ksoc-sync/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-sync/rbac.yaml
@@ -8,10 +8,10 @@ metadata:
     app_name: ksoc-sync
     app_version: {{ .Values.ksocSync.image.tag | quote }}
     maintained_by: ksoc
+  {{- with .Values.ksocSync.serviceAccountAnnotations }}
   annotations:
-    {{- with .Values.ksocSync.serviceAccountAnnotations }}
 {{ toYaml . | indent 4 }}
-    {{- end }}
+  {{- end }}
 automountServiceAccountToken: false
 
 ---

--- a/stable/ksoc-plugins/templates/ksoc-sync/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-sync/rbac.yaml
@@ -8,6 +8,10 @@ metadata:
     app_name: ksoc-sync
     app_version: {{ .Values.ksocSync.image.tag | quote }}
     maintained_by: ksoc
+  annotations:
+    {{- with .Values.ksocSync.serviceAccountAnnotations }}
+{{ toYaml . | indent 4 }}
+    {{- end }}
 automountServiceAccountToken: false
 
 ---

--- a/stable/ksoc-plugins/templates/ksoc-watch/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-watch/rbac.yaml
@@ -8,6 +8,10 @@ metadata:
     app_name: ksoc-watch
     app_version: {{ .Values.ksocWatch.image.tag | quote }}
     maintained_by: ksoc
+  annotations:
+    {{- with .Values.ksocWatch.serviceAccountAnnotations }}
+{{ toYaml . | indent 4 }}
+    {{- end }}
 automountServiceAccountToken: false
 
 ---

--- a/stable/ksoc-plugins/templates/ksoc-watch/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-watch/rbac.yaml
@@ -8,10 +8,10 @@ metadata:
     app_name: ksoc-watch
     app_version: {{ .Values.ksocWatch.image.tag | quote }}
     maintained_by: ksoc
+  {{- with .Values.ksocWatch.serviceAccountAnnotations }}
   annotations:
-    {{- with .Values.ksocWatch.serviceAccountAnnotations }}
 {{ toYaml . | indent 4 }}
-    {{- end }}
+  {{- end }}
 automountServiceAccountToken: false
 
 ---

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -81,6 +81,7 @@ ksocGuard:
     timeoutSeconds: 10
   nodeSelector: {}
   tolerations: []
+  serviceAccountAnnotations: {}
 
 ksocSbom:
   enabled: true
@@ -136,6 +137,7 @@ ksocSync:
   podAnnotations: {}
   nodeSelector: {}
   tolerations: []
+  serviceAccountAnnotations: {}
 
 ksocWatch:
   enabled: true
@@ -171,6 +173,7 @@ ksocWatch:
   customResourceRules:
     allowlist: []
     denylist: []
+  serviceAccountAnnotations: {}
 
 ksocNodeAgent:
   enabled: false
@@ -239,6 +242,7 @@ ksocNodeAgent:
       maxUnavailable: 1
       # -- The maximum number of pods that can be scheduled above the desired number of pods. Can be an absolute number or percent, e.g. `5` or `"10%"`
       maxSurge: 0
+  serviceAccountAnnotations: {}
 
   # -- K9 is an in-cluster response plugin.  It will request any queued commands from
   # -- the Rad Security backend, and execute them in the cluster.  Each capability must
@@ -273,6 +277,7 @@ k9:
     enableLabelPod: false
   tolerations: []
   nodeSelector: {}
+  serviceAccountAnnotations: {}
 
 # Toggles support for Openshift. Please note that functionality is limited at the moment.
 openshift:


### PR DESCRIPTION
To support IRSA, we need to allow the configuration of Service Account annotations across all of our services in our helm chart. 


<!--
Thank you for contributing to ksoclabs/ksoc-plugins-helm-chart.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

#### Special notes for your reviewer

#### Checklist

- [X] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [X] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated
- [X] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
