### PR TITLE
Add possibility to use AWS Secret Manager

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.6.6
+version: 1.6.7
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -17,7 +17,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: added
-      description: Bump ksoc-node-agent to support agent instrumentation
+      description: Add possibility to use AWS Secrets Manager for secrets
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -198,7 +198,7 @@ ksoc:
   clusterName: "please add a name here"
 ```
 
-You can manually create the file or use `values.yaml`file downloaded from the RAD Security UI.
+You can manually create the file or use `values.yaml` file downloaded from the RAD Security UI.
 
 **NOTE:** Be sure to set the `clusterName` value with a descriptive name of the cluster where you will be installing RAD Security.
 
@@ -228,6 +228,49 @@ ksoc:
 ```
 
 RAD Security ksoc-guard plugin integrates with the Kubernetes admission controller. All admission controller communications require TLS. RAD Security Helm chart installs and ksoc-guard utilizes Let’s Encrypt to automate the issuance and renewal of certificates using the cert-manager add-on.
+
+#### 4.2 AWS Secret Manager
+
+If you are using AWS Secret Manager to store your access key, you can use the `awsSecretId` parameter to specify the secret ID. Secret ID could be the name of the secret or the full ARN. The service accounts need to have access to the secret in AWS, via IRSA or EKS Pod Identity. There is no need to provide `base64AccessKeyId` and `base64SecretKey` in this case.
+
+```yaml
+ksoc:
+  awsSecretId: "arn:aws:secretsmanager:us-west-2:123456789012:secret:my-secret
+```
+
+Format of the secret in AWS Secret Manager:
+
+```json
+{
+  "access-key-id": "value copied from the RAD Security UI, decoded from base64",
+  "secret-key": "value copied from the RAD Security UI, decoded from base64"
+}
+```
+
+If IRSA is used, following `serviceAccountAnnotations` should be added to the `values.yaml` file:
+
+```yaml
+ksocGuard:
+  serviceAccountAnnotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/role-name-which-can-read-secrets
+ksocSbom:
+  serviceAccountAnnotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/role-name-which-can-read-secrets
+ksocSync:
+  serviceAccountAnnotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/role-name-which-can-read-secrets
+ksocWatch:
+  serviceAccountAnnotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/role-name-which-can-read-secrets
+k9:
+  enabled: true
+  serviceAccountAnnotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/role-name-which-can-read-secrets
+ksocNodeAgent:
+  enabled: true
+  serviceAccountAnnotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/role-name-which-can-read-secrets
+```
 
 ### 5. Installing the KSOC plugins
 
@@ -417,7 +460,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | k9.backend.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-backend-agent"` |  |
-| k9.backend.image.tag | string | `"v0.0.32"` |  |
+| k9.backend.image.tag | string | `"v0.0.33"` |  |
 | k9.capabilities.enableGetLogs | bool | `false` |  |
 | k9.capabilities.enableLabelPod | bool | `false` |  |
 | k9.capabilities.enableQuarantine | bool | `false` |  |
@@ -426,7 +469,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | k9.enabled | bool | `false` |  |
 | k9.frontend.agentActionPollInterval | string | `"5s"` | The interval in which the agent polls the backend for new actions. |
 | k9.frontend.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-frontend-agent"` |  |
-| k9.frontend.image.tag | string | `"v0.0.32"` |  |
+| k9.frontend.image.tag | string | `"v0.0.33"` |  |
 | k9.nodeSelector | object | `{}` |  |
 | k9.replicas | int | `1` |  |
 | k9.resources.limits.cpu | string | `"250m"` |  |
@@ -440,13 +483,14 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksoc.accessKeySecretNameOverride | string | `""` | The name of the custom secret containing Access Key. |
 | ksoc.apiKey | string | `""` | The combined API key to authenticate with KSOC |
 | ksoc.apiUrl | string | `"https://api.ksoc.com"` | The base URL for the KSOC API. |
+| ksoc.awsSecretId | string | `""` | If `awsSecretId` is provided service accounts needs to have access to the secret in AWS, via IRSA or EKS Pod Identity. |
 | ksoc.base64AccessKeyId | string | `""` | The ID of the Access Key used in this cluster (base64). |
 | ksoc.base64SecretKey | string | `""` | The secret key part of the Access Key used in this cluster (base64). |
 | ksoc.clusterName | string | `""` | The name of the cluster you want displayed in KSOC. |
 | ksoc.seccompProfile | object | `{"enabled":true}` | Enable seccompProfile for all KSOC pods |
 | ksocBootstrapper.env | object | `{}` |  |
 | ksocBootstrapper.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-bootstrapper"` | The image to use for the ksoc-bootstrapper deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-bootstrapper). |
-| ksocBootstrapper.image.tag | string | `"v1.1.7"` |  |
+| ksocBootstrapper.image.tag | string | `"v1.1.8"` |  |
 | ksocBootstrapper.nodeSelector | object | `{}` |  |
 | ksocBootstrapper.podAnnotations | object | `{}` |  |
 | ksocBootstrapper.resources.limits.cpu | string | `"100m"` |  |
@@ -463,7 +507,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocGuard.config.LOG_LEVEL | string | `"info"` | The log level to use. |
 | ksocGuard.enabled | bool | `true` |  |
 | ksocGuard.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-guard"` | The image to use for the ksoc-guard deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-guard). |
-| ksocGuard.image.tag | string | `"v1.1.12"` |  |
+| ksocGuard.image.tag | string | `"v1.1.13"` |  |
 | ksocGuard.nodeSelector | object | `{}` |  |
 | ksocGuard.podAnnotations | object | `{}` |  |
 | ksocGuard.replicas | int | `1` |  |
@@ -505,7 +549,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocNodeAgent.exporter.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | ksocNodeAgent.exporter.resources.requests.memory | string | `"128Mi"` |  |
 | ksocNodeAgent.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-node-agent"` |  |
-| ksocNodeAgent.image.tag | string | `"v0.0.21"` |  |
+| ksocNodeAgent.image.tag | string | `"v0.0.22"` |  |
 | ksocNodeAgent.nodeName | string | `""` |  |
 | ksocNodeAgent.nodeSelector | object | `{}` |  |
 | ksocNodeAgent.reachableVulnerabilitiesEnabled | bool | `true` |  |
@@ -520,7 +564,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocSbom.env.MUTATE_IMAGE | bool | `true` | Whether to mutate the image in pod spec by adding digest at the end. By default, digests are added to images to ensure that the image that runs in the cluster matches the digest of the build.  Disable this if your continuous deployment reconciler requires a strict image tag match. |
 | ksocSbom.env.SBOM_FORMAT | string | `"cyclonedx-json"` | The format of the generated SBOM. Currently we support: syft-json,cyclonedx-json,spdx-json |
 | ksocSbom.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-sbom"` | The image to use for the ksoc-sbom deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-sbom). |
-| ksocSbom.image.tag | string | `"v1.1.26"` |  |
+| ksocSbom.image.tag | string | `"v1.1.27"` |  |
 | ksocSbom.nodeSelector | object | `{}` |  |
 | ksocSbom.podAnnotations | object | `{}` |  |
 | ksocSbom.resources.limits.cpu | string | `"1000m"` |  |
@@ -535,7 +579,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocSync.enabled | bool | `true` |  |
 | ksocSync.env | object | `{}` |  |
 | ksocSync.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-sync"` | The image to use for the ksoc-sync deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-sync). |
-| ksocSync.image.tag | string | `"v1.1.9"` |  |
+| ksocSync.image.tag | string | `"v1.1.10"` |  |
 | ksocSync.nodeSelector | object | `{}` |  |
 | ksocSync.podAnnotations | object | `{}` |  |
 | ksocSync.resources.limits.cpu | string | `"200m"` |  |
@@ -550,7 +594,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocWatch.enabled | bool | `true` |  |
 | ksocWatch.env.RECONCILIATION_AT_START | bool | `false` | Whether to trigger reconciliation at startup. |
 | ksocWatch.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-watch"` | The image to use for the ksoc-watch deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-watch). |
-| ksocWatch.image.tag | string | `"v1.1.21"` |  |
+| ksocWatch.image.tag | string | `"v1.1.22"` |  |
 | ksocWatch.ingestCustomResources | bool | `false` | If set will allow ingesting Custom Resources specified in `customResourceRules` |
 | ksocWatch.nodeSelector | object | `{}` |  |
 | ksocWatch.podAnnotations | object | `{}` |  |

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -483,7 +483,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksoc.accessKeySecretNameOverride | string | `""` | The name of the custom secret containing Access Key. |
 | ksoc.apiKey | string | `""` | The combined API key to authenticate with KSOC |
 | ksoc.apiUrl | string | `"https://api.ksoc.com"` | The base URL for the KSOC API. |
-| ksoc.awsSecretId | string | `""` | If `awsSecretId` is provided service accounts needs to have access to the secret in AWS, via IRSA or EKS Pod Identity. |
+| ksoc.awsSecretId | string | `""` | The Secret Name or Secret ARN containing the Access Key. If provided, plugins try to read the Access Key from the AWS Secret Manager. Plugins expect following keys in the secret: `access-key-id` and `secret-key`. If the secret is not found, the plugin falls back to the `base64AccessKeyId` and `base64SecretKey` values. If `awsSecretId` is provided service accounts needs to have access to the secret in AWS, via IRSA or EKS Pod Identity. |
 | ksoc.base64AccessKeyId | string | `""` | The ID of the Access Key used in this cluster (base64). |
 | ksoc.base64SecretKey | string | `""` | The secret key part of the Access Key used in this cluster (base64). |
 | ksoc.clusterName | string | `""` | The name of the cluster you want displayed in KSOC. |

--- a/stable/ksoc-plugins/README.md.gotmpl
+++ b/stable/ksoc-plugins/README.md.gotmpl
@@ -198,7 +198,7 @@ ksoc:
   clusterName: "please add a name here"
 ```
 
-You can manually create the file or use `values.yaml`file downloaded from the RAD Security UI.
+You can manually create the file or use `values.yaml` file downloaded from the RAD Security UI.
 
 **NOTE:** Be sure to set the `clusterName` value with a descriptive name of the cluster where you will be installing RAD Security.
 
@@ -228,6 +228,49 @@ ksoc:
 ```
 
 RAD Security ksoc-guard plugin integrates with the Kubernetes admission controller. All admission controller communications require TLS. RAD Security Helm chart installs and ksoc-guard utilizes Let’s Encrypt to automate the issuance and renewal of certificates using the cert-manager add-on.
+
+#### 4.2 AWS Secret Manager
+
+If you are using AWS Secret Manager to store your access key, you can use the `awsSecretId` parameter to specify the secret ID. Secret ID could be the name of the secret or the full ARN. The service accounts need to have access to the secret in AWS, via IRSA or EKS Pod Identity. There is no need to provide `base64AccessKeyId` and `base64SecretKey` in this case.
+
+```yaml
+ksoc:
+  awsSecretId: "arn:aws:secretsmanager:us-west-2:123456789012:secret:my-secret
+```
+
+Format of the secret in AWS Secret Manager:
+
+```json
+{
+  "access-key-id": "value copied from the RAD Security UI, decoded from base64",
+  "secret-key": "value copied from the RAD Security UI, decoded from base64"
+}
+```
+
+If IRSA is used, following `serviceAccountAnnotations` should be added to the `values.yaml` file:
+
+```yaml
+ksocGuard:
+  serviceAccountAnnotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/role-name-which-can-read-secrets
+ksocSbom:
+  serviceAccountAnnotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/role-name-which-can-read-secrets
+ksocSync:
+  serviceAccountAnnotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/role-name-which-can-read-secrets
+ksocWatch:
+  serviceAccountAnnotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/role-name-which-can-read-secrets
+k9:
+  enabled: true
+  serviceAccountAnnotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/role-name-which-can-read-secrets
+ksocNodeAgent:
+  enabled: true
+  serviceAccountAnnotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/role-name-which-can-read-secrets
+```
 
 ### 5. Installing the KSOC plugins
 

--- a/stable/ksoc-plugins/templates/_helpers.tpl
+++ b/stable/ksoc-plugins/templates/_helpers.tpl
@@ -87,7 +87,12 @@ ksoc-bootstrap initContainer
       value: {{ .Values.ksoc.clusterName }}
     - name: KSOC_NAMESPACE
       value: {{ .Release.Namespace }}
+    {{- if .Values.ksoc.awsSecretId }}
+    - name: RAD_AWS_SECRET_ID
+      value: {{ .Values.ksoc.awsSecretId }}
+    {{- else }}
 {{ include "ksoc-plugins.access-key-env-secret" . | indent 4 }}
+    {{- end }}
   volumeMounts:
   - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
     name: api-token

--- a/stable/ksoc-plugins/templates/ksoc-guard/deployment.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-guard/deployment.yaml
@@ -77,7 +77,12 @@ spec:
               value: {{ .Values.ksoc.apiUrl }}
             - name: KSOC_NAMESPACE
               value: {{ .Release.Namespace }}
+            {{- if .Values.ksoc.awsSecretId }}
+            - name: RAD_AWS_SECRET_ID
+              value: {{ .Values.ksoc.awsSecretId }}
+            {{- else }}
 {{ include "ksoc-plugins.access-key-env-secret" . | indent 12 }}
+            {{- end }}
             - name: INSTALL_CRDS
               value: "true"
             {{- range $key, $value := .Values.ksocGuard.config }}

--- a/stable/ksoc-plugins/templates/ksoc-k9/deployment.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-k9/deployment.yaml
@@ -97,7 +97,12 @@ spec:
             value: {{ .Values.ksoc.apiUrl }}
           - name: KSOC_NAMESPACE
             value: {{ .Release.Namespace }}
+          {{- if .Values.ksoc.awsSecretId }}
+          - name: RAD_AWS_SECRET_ID
+            value: {{ .Values.ksoc.awsSecretId }}
+          {{- else }}
 {{ include "ksoc-plugins.access-key-env-secret" . | indent 10 }}
+          {{- end }}
           - name: AGENT_ACTION_POLL_INTERVAL
             value: {{ .Values.k9.frontend.agentActionPollInterval }}
           - name: AGENT_DEPLOYMENT_NAMESPACE

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
@@ -54,6 +54,10 @@ spec:
               value: {{ .Values.ksoc.apiUrl }}
             - name: AGENT_KSOC_NAMESPACE
               value: {{ .Release.Namespace }}
+            {{- if .Values.ksoc.awsSecretId }}
+            - name: RAD_AWS_SECRET_ID
+              value: {{ .Values.ksoc.awsSecretId }}
+            {{- else }}
             - name: AGENT_KSOC_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -72,6 +76,7 @@ spec:
                   name: ksoc-access-key
                   {{ end -}}
                   key: secret-key
+            {{- end }}
             - name: HOST_ROOT
               value: /host
             {{- with .Values.ksocNodeAgent.agent.collectors }}
@@ -188,6 +193,10 @@ spec:
               value: {{ .Values.ksoc.apiUrl }}
             - name: EXPORTER_KSOC_NAMESPACE
               value: {{ .Release.Namespace }}
+            {{- if .Values.ksoc.awsSecretId }}
+            - name: RAD_AWS_SECRET_ID
+              value: {{ .Values.ksoc.awsSecretId }}
+            {{- else }}
             - name: EXPORTER_KSOC_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -206,12 +215,6 @@ spec:
                   name: ksoc-access-key
                   {{ end -}}
                   key: secret-key
-            - name: EXPORTER_PROVIDER_STDOUT_ENABLED
-              value: "false"
-            - name: EXPORTER_PROVIDER_KSOC_API_ENABLED
-              value: "true"
-            - name: EXPORTER_PROVIDER_KSOC_API_URL
-              value: {{ .Values.ksoc.apiUrl }}
             - name: EXPORTER_PROVIDER_KSOC_API_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -230,6 +233,13 @@ spec:
                   name: ksoc-access-key
                   {{ end -}}
                   key: secret-key
+            {{- end }}
+            - name: EXPORTER_PROVIDER_STDOUT_ENABLED
+              value: "false"
+            - name: EXPORTER_PROVIDER_KSOC_API_ENABLED
+              value: "true"
+            - name: EXPORTER_PROVIDER_KSOC_API_URL
+              value: {{ .Values.ksoc.apiUrl }}
             {{ if .Values.ksocNodeAgent.exporter.execFilters -}}
             {{- $filters := printf "execFilters: %s" (.Values.ksocNodeAgent.exporter.execFilters | toJson ) -}}
             - name: EXPORTER_EXEC_FILTERS

--- a/stable/ksoc-plugins/templates/ksoc-sbom/deployment.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-sbom/deployment.yaml
@@ -77,7 +77,12 @@ spec:
               value: {{ .Values.ksoc.apiUrl }}
             - name: KSOC_NAMESPACE
               value: {{ .Release.Namespace }}
+            {{- if .Values.ksoc.awsSecretId }}
+            - name: RAD_AWS_SECRET_ID
+              value: {{ .Values.ksoc.awsSecretId }}
+            {{- else }}
 {{ include "ksoc-plugins.access-key-env-secret" . | indent 12 }}
+            {{- end }}
             {{- range $key, $value := .Values.ksocSbom.env }}
             - name: "{{ $key }}"
               value: "{{ $value }}"

--- a/stable/ksoc-plugins/templates/ksoc-sync/deployment.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-sync/deployment.yaml
@@ -77,7 +77,12 @@ spec:
               value: {{ .Values.ksoc.apiUrl }}
             - name: KSOC_NAMESPACE
               value: {{ .Release.Namespace }}
+            {{- if .Values.ksoc.awsSecretId }}
+            - name: RAD_AWS_SECRET_ID
+              value: {{ .Values.ksoc.awsSecretId }}
+            {{- else }}
 {{ include "ksoc-plugins.access-key-env-secret" . | indent 12 }}
+            {{- end }}
             {{- range $key, $value := .Values.ksocSync.env }}
             - name: "{{ $key }}"
               value: "{{ $value }}"

--- a/stable/ksoc-plugins/templates/ksoc-watch/deployment.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-watch/deployment.yaml
@@ -77,7 +77,12 @@ spec:
               value: {{ .Values.ksoc.apiUrl }}
             - name: KSOC_NAMESPACE
               value: {{ .Release.Namespace }}
+            {{- if .Values.ksoc.awsSecretId }}
+            - name: RAD_AWS_SECRET_ID
+              value: {{ .Values.ksoc.awsSecretId }}
+            {{- else }}
 {{ include "ksoc-plugins.access-key-env-secret" . | indent 12 }}
+            {{- end }}
             {{- if .Values.ksocWatch.ingestCustomResources }}
             - name: INGEST_CUSTOM_RESOURCES
               value: "true"

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -8,8 +8,8 @@ ksoc:
   # -- The secret key part of the Access Key used in this cluster (base64).
   base64SecretKey: ""
   # -- The Secret Name or Secret ARN containing the Access Key. If provided, plugins try to read the Access Key from the AWS Secret Manager.
-  # -- Plugins expect following keys in the secret: `access-key-id` and `secret-key`. If the secret is not found, the plugin falls back to the `base64AccessKeyId` and `base64SecretKey` values.
-  # -- If `awsSecretId` is provided service accounts needs to have access to the secret in AWS, via IRSA or EKS Pod Identity.
+  # Plugins expect following keys in the secret: `access-key-id` and `secret-key`. If the secret is not found, the plugin falls back to the `base64AccessKeyId` and `base64SecretKey` values.
+  # If `awsSecretId` is provided service accounts needs to have access to the secret in AWS, via IRSA or EKS Pod Identity.
   awsSecretId: ""
   # -- The name of the cluster you want displayed in KSOC.
   clusterName: ""

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -7,6 +7,10 @@ ksoc:
   base64AccessKeyId: ""
   # -- The secret key part of the Access Key used in this cluster (base64).
   base64SecretKey: ""
+  # -- The Secret Name or Secret ARN containing the Access Key. If provided, plugins try to read the Access Key from the AWS Secret Manager.
+  # -- Plugins expect following keys in the secret: `access-key-id` and `secret-key`. If the secret is not found, the plugin falls back to the `base64AccessKeyId` and `base64SecretKey` values.
+  # -- If `awsSecretId` is provided service accounts needs to have access to the secret in AWS, via IRSA or EKS Pod Identity.
+  awsSecretId: ""
   # -- The name of the cluster you want displayed in KSOC.
   clusterName: ""
   # -- The name of the custom secret containing Access Key.
@@ -33,7 +37,7 @@ ksocBootstrapper:
   image:
     # -- The image to use for the ksoc-bootstrapper deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-bootstrapper).
     repository: us.gcr.io/ksoc-public/ksoc-bootstrapper
-    tag: v1.1.7
+    tag: v1.1.8
   env: {}
   resources:
     limits:
@@ -53,7 +57,7 @@ ksocGuard:
   image:
     # -- The image to use for the ksoc-guard deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-guard).
     repository: us.gcr.io/ksoc-public/ksoc-guard
-    tag: v1.1.12
+    tag: v1.1.13
   config:
     # -- Whether to block on error.
     BLOCK_ON_ERROR: false
@@ -88,7 +92,7 @@ ksocSbom:
   image:
     # -- The image to use for the ksoc-sbom deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-sbom).
     repository: us.gcr.io/ksoc-public/ksoc-sbom
-    tag: v1.1.26
+    tag: v1.1.27
   env:
     # -- Whether to mutate the image in pod spec by adding digest at the end. By default, digests are added to images to ensure
     # that the image that runs in the cluster matches the digest of the build.  Disable this if your continuous deployment
@@ -123,7 +127,7 @@ ksocSync:
   image:
     # -- The image to use for the ksoc-sync deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-sync).
     repository: us.gcr.io/ksoc-public/ksoc-sync
-    tag: v1.1.9
+    tag: v1.1.10
   env: {}
   resources:
     limits:
@@ -144,7 +148,7 @@ ksocWatch:
   image:
     # -- The image to use for the ksoc-watch deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-watch).
     repository: us.gcr.io/ksoc-public/ksoc-watch
-    tag: v1.1.21
+    tag: v1.1.22
   env:
     # -- Whether to trigger reconciliation at startup.
     RECONCILIATION_AT_START: false
@@ -180,7 +184,7 @@ ksocNodeAgent:
   reachableVulnerabilitiesEnabled: true
   image:
     repository: us.gcr.io/ksoc-public/ksoc-node-agent
-    tag: v0.0.21
+    tag: v0.0.22
   agent:
     env:
       AGENT_LOG_LEVEL: INFO
@@ -253,13 +257,13 @@ k9:
   frontend:
     image:
       repository: us.gcr.io/ksoc-public/ksoc-frontend-agent
-      tag: v0.0.32
+      tag: v0.0.33
     # -- The interval in which the agent polls the backend for new actions.
     agentActionPollInterval: "5s"
   backend:
     image:
       repository: us.gcr.io/ksoc-public/ksoc-backend-agent
-      tag: v0.0.32
+      tag: v0.0.33
   resources:
     limits:
       cpu: 250m


### PR DESCRIPTION
#### What this PR does / why we need it
Add possibility to use AWS Secret Manager for keeping `access-key-id` and `secret-key` 

#### Special notes for your reviewer
nope 

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
