### PR TITLE
Change plugin names and registry

### DIFF
--- a/scripts/modify_chart_for_aws_marketplace.sh
+++ b/scripts/modify_chart_for_aws_marketplace.sh
@@ -3,14 +3,15 @@
 FILE="./stable/ksoc-plugins/values.yaml"
 
 GCR_REGISTRY_NAME="us.gcr.io/ksoc-public"
-FALCO_REGISTRY="docker.io/falcosecurity"
+ECR_REGISTRY_NAME="public.ecr.aws/n8h5y2v5/rad-security"
 ECR_PUBLIC_REGISTRY="public.ecr.aws/eks-distro/kubernetes"
 
-ECR_REGISTRY_NAME="709825985650.dkr.ecr.us-east-1.amazonaws.com/ksoc-labs"
+AWS_MARKETPLACE_REGISTRY_NAME="709825985650.dkr.ecr.us-east-1.amazonaws.com/ksoc-labs"
 
-sed -i "s|$ECR_PUBLIC_REGISTRY|$ECR_REGISTRY_NAME|g" "$FILE"
-sed -i "s|$GCR_REGISTRY_NAME|$ECR_REGISTRY_NAME|g" "$FILE"
-sed -i "s|$FALCO_REGISTRY|$ECR_REGISTRY_NAME|g" "$FILE"
+
+sed -i "s|$ECR_PUBLIC_REGISTRY|$AWS_MARKETPLACE_REGISTRY_NAME|g" "$FILE"
+sed -i "s|$GCR_REGISTRY_NAME|$AWS_MARKETPLACE_REGISTRY_NAME|g" "$FILE"
+sed -i "s|$ECR_REGISTRY_NAME|$AWS_MARKETPLACE_REGISTRY_NAME|g" "$FILE"
 sed -i '/# --/d' "$FILE"
 
 yq e -i '.eksAddon.enabled = true' $FILE

--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.7.1
+version: 1.8.0
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -16,9 +16,9 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Disable OCI enrichement in Node Agent
-  artifacthub.io/containsSecurityUpdates: "false"
+    - kind: added
+      description: Changed container registry to public.ecr.aws/n8h5y2v5/rad-security
+  artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: source
       url: https://github.com/ksoclabs/ksoc-plugins-helm-chart

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -556,7 +556,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocNodeAgent.exporter.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | ksocNodeAgent.exporter.resources.requests.memory | string | `"128Mi"` |  |
 | ksocNodeAgent.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-runtime"` |  |
-| ksocNodeAgent.image.tag | string | `"v0.1.1"` |  |
+| ksocNodeAgent.image.tag | string | `"v0.1.2"` |  |
 | ksocNodeAgent.nodeName | string | `""` |  |
 | ksocNodeAgent.nodeSelector | object | `{}` |  |
 | ksocNodeAgent.reachableVulnerabilitiesEnabled | bool | `true` |  |

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -493,8 +493,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksoc.clusterName | string | `""` | The name of the cluster you want displayed in KSOC. |
 | ksoc.seccompProfile | object | `{"enabled":true}` | Enable seccompProfile for all KSOC pods |
 | ksocBootstrapper.env | object | `{}` |  |
-| ksocBootstrapper.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-bootstrapper"` | The image to use for the ksoc-bootstrapper deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-bootstrapper). |
-| ksocBootstrapper.image.tag | string | `"v1.1.8"` |  |
+| ksocBootstrapper.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-bootstrapper"` | The image to use for the ksoc-bootstrapper deployment |
+| ksocBootstrapper.image.tag | string | `"v1.1.9"` |  |
 | ksocBootstrapper.nodeSelector | object | `{}` |  |
 | ksocBootstrapper.podAnnotations | object | `{}` |  |
 | ksocBootstrapper.resources.limits.cpu | string | `"100m"` |  |
@@ -510,8 +510,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocGuard.config.ENABLE_WARNING_LOGS | bool | `false` | Whether to enable warning logs. |
 | ksocGuard.config.LOG_LEVEL | string | `"info"` | The log level to use. |
 | ksocGuard.enabled | bool | `true` |  |
-| ksocGuard.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-guard"` | The image to use for the ksoc-guard deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-guard). |
-| ksocGuard.image.tag | string | `"v1.1.13"` |  |
+| ksocGuard.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-guard"` | The image to use for the ksoc-guard deployment |
+| ksocGuard.image.tag | string | `"v1.1.14"` |  |
 | ksocGuard.nodeSelector | object | `{}` |  |
 | ksocGuard.podAnnotations | object | `{}` |  |
 | ksocGuard.replicas | int | `1` |  |
@@ -554,8 +554,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocNodeAgent.exporter.resources.requests.cpu | string | `"100m"` |  |
 | ksocNodeAgent.exporter.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | ksocNodeAgent.exporter.resources.requests.memory | string | `"128Mi"` |  |
-| ksocNodeAgent.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-node-agent"` |  |
-| ksocNodeAgent.image.tag | string | `"v0.0.25"` |  |
+| ksocNodeAgent.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-runtime"` |  |
+| ksocNodeAgent.image.tag | string | `"v0.1.1"` |  |
 | ksocNodeAgent.nodeName | string | `""` |  |
 | ksocNodeAgent.nodeSelector | object | `{}` |  |
 | ksocNodeAgent.reachableVulnerabilitiesEnabled | bool | `true` |  |
@@ -569,8 +569,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocSbom.env.MUTATE_ANNOTATIONS | bool | `false` | Whether to mutate the annotations in pod spec by adding images digests. Annotations can be used to track image digests in addition to, or instead of the image tag mutation. |
 | ksocSbom.env.MUTATE_IMAGE | bool | `true` | Whether to mutate the image in pod spec by adding digest at the end. By default, digests are added to images to ensure that the image that runs in the cluster matches the digest of the build.  Disable this if your continuous deployment reconciler requires a strict image tag match. |
 | ksocSbom.env.SBOM_FORMAT | string | `"cyclonedx-json"` | The format of the generated SBOM. Currently we support: syft-json,cyclonedx-json,spdx-json |
-| ksocSbom.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-sbom"` | The image to use for the ksoc-sbom deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-sbom). |
-| ksocSbom.image.tag | string | `"v1.1.27"` |  |
+| ksocSbom.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-sbom"` | The image to use for the ksoc-sbom deployment |
+| ksocSbom.image.tag | string | `"v1.1.28"` |  |
 | ksocSbom.nodeSelector | object | `{}` |  |
 | ksocSbom.podAnnotations | object | `{}` |  |
 | ksocSbom.resources.limits.cpu | string | `"1000m"` |  |
@@ -584,8 +584,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocSbom.webhook.timeoutSeconds | int | `10` |  |
 | ksocSync.enabled | bool | `true` |  |
 | ksocSync.env | object | `{}` |  |
-| ksocSync.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-sync"` | The image to use for the ksoc-sync deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-sync). |
-| ksocSync.image.tag | string | `"v1.1.10"` |  |
+| ksocSync.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-sync"` | The image to use for the ksoc-sync deployment |
+| ksocSync.image.tag | string | `"v1.1.11"` |  |
 | ksocSync.nodeSelector | object | `{}` |  |
 | ksocSync.podAnnotations | object | `{}` |  |
 | ksocSync.resources.limits.cpu | string | `"200m"` |  |
@@ -599,8 +599,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocWatch.customResourceRules | object | `{"allowlist":[],"denylist":[]}` | Rules for Custom Resource ingestion containing allow- and denylists of rules specifying `apiGroups` and `resources`. E.g. `allowlist: apiGroups: ["custom.com"], resources: ["someResource", "otherResoure"]` Wildcards (`*`) can be used to match all. `customResourceRules.denylist` sets resources that should not be ingested. It has a priority over `customResourceRules.allowlist` to  deny resources allowed using a wildcard (`*`) match.  E.g. you can use `allowlist: apiGroups: ["custom.com"], resources: ["*"], denylist: apiGroups: ["custom.com"], resources: "excluded"` to ingest all resources within `custom.com` group but `excluded`. |
 | ksocWatch.enabled | bool | `true` |  |
 | ksocWatch.env.RECONCILIATION_AT_START | bool | `false` | Whether to trigger reconciliation at startup. |
-| ksocWatch.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-watch"` | The image to use for the ksoc-watch deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-watch). |
-| ksocWatch.image.tag | string | `"v1.1.22"` |  |
+| ksocWatch.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-watch"` | The image to use for the ksoc-watch deployment |
+| ksocWatch.image.tag | string | `"v1.1.23"` |  |
 | ksocWatch.ingestCustomResources | bool | `false` | If set will allow ingesting Custom Resources specified in `customResourceRules` |
 | ksocWatch.nodeSelector | object | `{}` |  |
 | ksocWatch.podAnnotations | object | `{}` |  |

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -98,6 +98,7 @@ k9:
     enableGetLogs: true
     enableLabelPod: true
 ```
+
 Terminate Pod: Allows the plugin to terminate a pod in the cluster.
 Terminate Namespace: Allows the plugin to terminate a namespace in the cluster.
 Quarantine: Allows the plugin to quarantine a pod in the cluster via a NetworkPolicy to prevent it from communicating over the network.

--- a/stable/ksoc-plugins/README.md.gotmpl
+++ b/stable/ksoc-plugins/README.md.gotmpl
@@ -98,6 +98,7 @@ k9:
     enableGetLogs: true
     enableLabelPod: true
 ```
+
 Terminate Pod: Allows the plugin to terminate a pod in the cluster.
 Terminate Namespace: Allows the plugin to terminate a namespace in the cluster.
 Quarantine: Allows the plugin to quarantine a pod in the cluster via a NetworkPolicy to prevent it from communicating over the network.

--- a/stable/ksoc-plugins/templates/ksoc-guard/dynamic-config.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-guard/dynamic-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ksoc-guard-dynamic-configuration
+  name: rad-guard-dynamic-configuration
   namespace: {{ .Release.Namespace }}
   labels:
     app_name: ksoc-guard

--- a/stable/ksoc-plugins/templates/ksoc-guard/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-guard/rbac.yaml
@@ -43,7 +43,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    resourceNames: [ "ksoc-guard-dynamic-configuration" ]
+    resourceNames: [ "rad-guard-dynamic-configuration" ]
     verbs: ["get", "list", "watch"]
 
 ---

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/daemonset.yaml
@@ -142,6 +142,8 @@ spec:
           resources:
 {{ toYaml .Values.ksocNodeAgent.agent.resources | indent 12 }}
           securityContext:
+            appArmorProfile:
+              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/dynamic-config.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/dynamic-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ksoc-node-agent-dynamic-configuration
+  name: rad-runtime-dynamic-configuration
   namespace: {{ .Release.Namespace }}
   labels:
     app_name: ksoc-node-agent
@@ -15,7 +15,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ksoc-node-agent-exporter-dynamic-configuration
+  name: rad-runtime-exporter-dynamic-configuration
   namespace: {{ .Release.Namespace }}
   labels:
     app_name: ksoc-node-agent

--- a/stable/ksoc-plugins/templates/ksoc-node-agent/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-node-agent/rbac.yaml
@@ -28,7 +28,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    resourceNames: [ "ksoc-node-agent-dynamic-configuration", "ksoc-node-agent-exporter-dynamic-configuration" ]
+    resourceNames: [ "rad-runtime-dynamic-configuration", "rad-runtime-exporter-dynamic-configuration" ]
     verbs: ["get", "list", "watch"]
 
 ---

--- a/stable/ksoc-plugins/templates/ksoc-sbom/dynamic-config.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-sbom/dynamic-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ksoc-sbom-dynamic-configuration
+  name: rad-sbom-dynamic-configuration
   namespace: {{ .Release.Namespace }}
   labels:
     app_name: ksoc-sbom

--- a/stable/ksoc-plugins/templates/ksoc-sbom/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-sbom/rbac.yaml
@@ -43,7 +43,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    resourceNames: [ "ksoc-sbom-dynamic-configuration" ]
+    resourceNames: [ "rad-sbom-dynamic-configuration" ]
     verbs: ["get", "list", "watch"]
 
 ---

--- a/stable/ksoc-plugins/templates/ksoc-sync/dynamic-config.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-sync/dynamic-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ksoc-sync-dynamic-configuration
+  name: rad-sync-dynamic-configuration
   namespace: {{ .Release.Namespace }}
   labels:
     app_name: ksoc-sync

--- a/stable/ksoc-plugins/templates/ksoc-sync/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-sync/rbac.yaml
@@ -43,7 +43,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    resourceNames: [ "ksoc-guard-dynamic-configuration", "ksoc-sbom-dynamic-configuration", "ksoc-sync-dynamic-configuration", "ksoc-watch-dynamic-configuration" ]
+    resourceNames: [ "rad-guard-dynamic-configuration", "rad-sbom-dynamic-configuration", "rad-sync-dynamic-configuration", "rad-watch-dynamic-configuration", "rad-runtime-dynamic-configuration", "rad-runtime-exporter-dynamic-configuration" ]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 ---

--- a/stable/ksoc-plugins/templates/ksoc-watch/dynamic-config.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-watch/dynamic-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ksoc-watch-dynamic-configuration
+  name: rad-watch-dynamic-configuration
   namespace: {{ .Release.Namespace }}
   labels:
     app_name: ksoc-watch

--- a/stable/ksoc-plugins/templates/ksoc-watch/rbac.yaml
+++ b/stable/ksoc-plugins/templates/ksoc-watch/rbac.yaml
@@ -43,7 +43,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    resourceNames: [ "ksoc-watch-dynamic-configuration" ]
+    resourceNames: [ "rad-watch-dynamic-configuration" ]
     verbs: ["get", "list", "watch"]
 
 ---

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -35,9 +35,9 @@ priorityClass:
 
 ksocBootstrapper:
   image:
-    # -- The image to use for the ksoc-bootstrapper deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-bootstrapper).
-    repository: us.gcr.io/ksoc-public/ksoc-bootstrapper
-    tag: v1.1.8
+    # -- The image to use for the ksoc-bootstrapper deployment
+    repository: public.ecr.aws/n8h5y2v5/rad-security/rad-bootstrapper
+    tag: v1.1.9
   env: {}
   resources:
     limits:
@@ -55,9 +55,9 @@ ksocBootstrapper:
 ksocGuard:
   enabled: true
   image:
-    # -- The image to use for the ksoc-guard deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-guard).
-    repository: us.gcr.io/ksoc-public/ksoc-guard
-    tag: v1.1.13
+    # -- The image to use for the ksoc-guard deployment
+    repository: public.ecr.aws/n8h5y2v5/rad-security/rad-guard
+    tag: v1.1.14
   config:
     # -- Whether to block on error.
     BLOCK_ON_ERROR: false
@@ -90,9 +90,9 @@ ksocGuard:
 ksocSbom:
   enabled: true
   image:
-    # -- The image to use for the ksoc-sbom deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-sbom).
-    repository: us.gcr.io/ksoc-public/ksoc-sbom
-    tag: v1.1.27
+    # -- The image to use for the ksoc-sbom deployment
+    repository: public.ecr.aws/n8h5y2v5/rad-security/rad-sbom
+    tag: v1.1.28
   env:
     # -- Whether to mutate the image in pod spec by adding digest at the end. By default, digests are added to images to ensure
     # that the image that runs in the cluster matches the digest of the build.  Disable this if your continuous deployment
@@ -125,9 +125,9 @@ ksocSbom:
 ksocSync:
   enabled: true
   image:
-    # -- The image to use for the ksoc-sync deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-sync).
-    repository: us.gcr.io/ksoc-public/ksoc-sync
-    tag: v1.1.10
+    # -- The image to use for the ksoc-sync deployment
+    repository: public.ecr.aws/n8h5y2v5/rad-security/rad-sync
+    tag: v1.1.11
   env: {}
   resources:
     limits:
@@ -146,9 +146,9 @@ ksocSync:
 ksocWatch:
   enabled: true
   image:
-    # -- The image to use for the ksoc-watch deployment (located at https://console.cloud.google.com/gcr/images/ksoc-public/us/ksoc-watch).
-    repository: us.gcr.io/ksoc-public/ksoc-watch
-    tag: v1.1.22
+    # -- The image to use for the ksoc-watch deployment
+    repository: public.ecr.aws/n8h5y2v5/rad-security/rad-watch
+    tag: v1.1.23
   env:
     # -- Whether to trigger reconciliation at startup.
     RECONCILIATION_AT_START: false
@@ -183,8 +183,8 @@ ksocNodeAgent:
   enabled: false
   reachableVulnerabilitiesEnabled: true
   image:
-    repository: us.gcr.io/ksoc-public/ksoc-node-agent
-    tag: v0.0.25
+    repository: public.ecr.aws/n8h5y2v5/rad-security/rad-runtime
+    tag: v0.1.1
   agent:
     env:
       AGENT_LOG_LEVEL: INFO

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -184,7 +184,7 @@ ksocNodeAgent:
   reachableVulnerabilitiesEnabled: true
   image:
     repository: public.ecr.aws/n8h5y2v5/rad-security/rad-runtime
-    tag: v0.1.1
+    tag: v0.1.2
   agent:
     env:
       AGENT_LOG_LEVEL: INFO


### PR DESCRIPTION
#### What this PR does / why we need it
This should be last - or one of the last version of this helm chart. We should switch to: https://github.com/rad-security/plugins-helm-chart soon 

Changes:
- improved authorization mechanism
- all plugins are now `rad-`
- removed all `ksoc` names from the plugins
- use new ECR registry

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
