### PR TITLE
Downgrade node-agent to skip enriching from OCI Config

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.7.0
+version: 1.7.1
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -16,8 +16,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: added
-      description: Add experimental support for OpenShift and cri-o
+    - kind: fixed
+      description: Disable OCI enrichement in Node Agent
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -555,7 +555,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocNodeAgent.exporter.resources.requests.ephemeral-storage | string | `"100Mi"` |  |
 | ksocNodeAgent.exporter.resources.requests.memory | string | `"128Mi"` |  |
 | ksocNodeAgent.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-node-agent"` |  |
-| ksocNodeAgent.image.tag | string | `"v0.0.26"` |  |
+| ksocNodeAgent.image.tag | string | `"v0.0.25"` |  |
 | ksocNodeAgent.nodeName | string | `""` |  |
 | ksocNodeAgent.nodeSelector | object | `{}` |  |
 | ksocNodeAgent.reachableVulnerabilitiesEnabled | bool | `true` |  |

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -184,7 +184,7 @@ ksocNodeAgent:
   reachableVulnerabilitiesEnabled: true
   image:
     repository: us.gcr.io/ksoc-public/ksoc-node-agent
-    tag: v0.0.26
+    tag: v0.0.25
   agent:
     env:
       AGENT_LOG_LEVEL: INFO


### PR DESCRIPTION
What this PR does / why we need it
Disabled support for Node Agent event  Enrichements using OCI config, because it sometimes uses incorrect values for image name.

Checklist
 [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
 Chart Version bumped in [Chart.yaml](https://github.com/ksoclabs/ksoc-plugins-helm-chart/pull/stable/ksoc-plugins/Chart.yaml)
 [README.md.gotmpl](https://github.com/ksoclabs/ksoc-plugins-helm-chart/pull/stable/ksoc-plugins/README.md.gotmpl) and [README.md](https://github.com/ksoclabs/ksoc-plugins-helm-chart/pull/stable/ksoc-plugins/README.md) updated
 [artifacthub.io/changes](https://github.com/ksoclabs/ksoc-plugins-helm-chart/pull/stable/ksoc-plugins/Chart.yaml) section updated