### PR TITLE
Bump rad-guard to support opa policies from rad and ksoc packages

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.9.0
+version: 1.9.1
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -17,7 +17,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: added
-      description: Adds a new version of Node Agent with built-in secrets scanner
+      description: Adds a support for opa policies from 'ksoc' and 'rad' packages
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -512,7 +512,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocGuard.config.LOG_LEVEL | string | `"info"` | The log level to use. |
 | ksocGuard.enabled | bool | `true` |  |
 | ksocGuard.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-guard"` | The image to use for the ksoc-guard deployment |
-| ksocGuard.image.tag | string | `"v1.1.14"` |  |
+| ksocGuard.image.tag | string | `"v1.1.15"` |  |
 | ksocGuard.nodeSelector | object | `{}` |  |
 | ksocGuard.podAnnotations | object | `{}` |  |
 | ksocGuard.replicas | int | `1` |  |

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -57,7 +57,7 @@ ksocGuard:
   image:
     # -- The image to use for the ksoc-guard deployment
     repository: public.ecr.aws/n8h5y2v5/rad-security/rad-guard
-    tag: v1.1.14
+    tag: v1.1.15
   config:
     # -- Whether to block on error.
     BLOCK_ON_ERROR: false


### PR DESCRIPTION
#### What this PR does / why we need it
Currently we support OPA policies only from ksoc packages, but after our rebranding we should support both packages

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
