### PR TITLE
Add possibility to check and generate newest SBOMs in the container registry

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.9.3
+version: 1.9.4
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -17,7 +17,7 @@ annotations:
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: added
-      description: Add documentation for the `IMAGE_PULL_SECRETS` config value in 'rad-sbom' component.
+      description: Add possibility to check and generate SBOMs for latests images in the container registry.
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -570,9 +570,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | ksocSbom.env.LOG_LEVEL | string | `"info"` | The log level to use.  Options are trace, debug, info, warn, error |
 | ksocSbom.env.MUTATE_ANNOTATIONS | bool | `false` | Whether to mutate the annotations in pod spec by adding images digests. Annotations can be used to track image digests in addition to, or instead of the image tag mutation. |
 | ksocSbom.env.MUTATE_IMAGE | bool | `true` | Whether to mutate the image in pod spec by adding digest at the end. By default, digests are added to images to ensure that the image that runs in the cluster matches the digest of the build.  Disable this if your continuous deployment reconciler requires a strict image tag match. |
+| ksocSbom.env.SBOM_CHECK_LATEST | bool | `false` | Experimental: Whether to check for the latest image in the container registry and generate SBOM for it. If deployed image has tag with semver format, rad-sbom tries to get the newest image, newest minor version, or newest patch version. If the tag is not in semver format, rad-sbom tries to get the newest image from the container registry based on the tag time. Please be aware that time-based algorithm requires many requests to the container registry and may be slow. It works only if credentials are provided. Please note that this feature is experimental and may not work with all container registries. |
 | ksocSbom.env.SBOM_FORMAT | string | `"cyclonedx-json"` | The format of the generated SBOM. Currently we support: syft-json,cyclonedx-json,spdx-json |
 | ksocSbom.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-sbom"` | The image to use for the ksoc-sbom deployment |
-| ksocSbom.image.tag | string | `"v1.1.28"` |  |
+| ksocSbom.image.tag | string | `"v1.1.30"` |  |
 | ksocSbom.nodeSelector | object | `{}` |  |
 | ksocSbom.podAnnotations | object | `{}` |  |
 | ksocSbom.resources.limits.cpu | string | `"1000m"` |  |

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -92,7 +92,7 @@ ksocSbom:
   image:
     # -- The image to use for the ksoc-sbom deployment
     repository: public.ecr.aws/n8h5y2v5/rad-security/rad-sbom
-    tag: v1.1.28
+    tag: v1.1.30
   env:
     # -- Whether to mutate the image in pod spec by adding digest at the end. By default, digests are added to images to ensure
     # that the image that runs in the cluster matches the digest of the build.  Disable this if your continuous deployment
@@ -108,6 +108,12 @@ ksocSbom:
     # additionally, you can specify the secrets here.
     # If you use AWS ECR private registry, we recommend to use EKS Pod Identity or IRSA to add access to "rad-sbom" to the ECR registry.
     IMAGE_PULL_SECRETS: ""
+    # -- Experimental: Whether to check for the latest image in the container registry and generate SBOM for it.
+    # If deployed image has tag with semver format, rad-sbom tries to get the newest image, newest minor version, or newest patch version.
+    # If the tag is not in semver format, rad-sbom tries to get the newest image from the container registry based on the tag time.
+    # Please be aware that time-based algorithm requires many requests to the container registry and may be slow. It works only if
+    # credentials are provided. Please note that this feature is experimental and may not work with all container registries.
+    SBOM_CHECK_LATEST: false
     # -- The log level to use.  Options are trace, debug, info, warn, error
     LOG_LEVEL: info
   resources:


### PR DESCRIPTION
#### What this PR does / why we need it
With newest version of rad-sbom we added possibility to check and generate newest SBOMs in the container registry

#### Checklist

- [x] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [x] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated
- [x] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
