### PR TITLE
Update k9 image repo to use ECR instead of GCR

### DIFF
--- a/stable/ksoc-plugins/Chart.yaml
+++ b/stable/ksoc-plugins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ksoc-plugins
-version: 1.9.9
+version: 1.9.10
 description: A Helm chart to run the KSOC plugins
 home: https://ksoc.com
 icon: https://ksoc.com/hubfs/Ksoc-logo.svg
@@ -16,8 +16,8 @@ annotations:
   artifacthub.io/category: security
   # Possible kind options are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: added
-      description: Bumped dependencies
+    - kind: changed
+      description: K9 images
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/links: |
     - name: source

--- a/stable/ksoc-plugins/README.md
+++ b/stable/ksoc-plugins/README.md
@@ -464,8 +464,8 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| k9.backend.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-backend-agent"` |  |
-| k9.backend.image.tag | string | `"v0.0.33"` |  |
+| k9.backend.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-k9-backend-agent"` |  |
+| k9.backend.image.tag | string | `"v0.0.37"` |  |
 | k9.capabilities.enableGetLogs | bool | `false` |  |
 | k9.capabilities.enableLabelPod | bool | `false` |  |
 | k9.capabilities.enableQuarantine | bool | `false` |  |
@@ -473,8 +473,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | k9.capabilities.enableTerminatePod | bool | `false` |  |
 | k9.enabled | bool | `false` |  |
 | k9.frontend.agentActionPollInterval | string | `"5s"` | The interval in which the agent polls the backend for new actions. |
-| k9.frontend.image.repository | string | `"us.gcr.io/ksoc-public/ksoc-frontend-agent"` |  |
-| k9.frontend.image.tag | string | `"v0.0.33"` |  |
+| k9.frontend.image.repository | string | `"public.ecr.aws/n8h5y2v5/rad-security/rad-k9-frontend-agent"` |  |
+| k9.frontend.image.tag | string | `"v0.0.37"` |  |
 | k9.nodeSelector | object | `{}` |  |
 | k9.replicas | int | `1` |  |
 | k9.resources.limits.cpu | string | `"250m"` |  |

--- a/stable/ksoc-plugins/values.yaml
+++ b/stable/ksoc-plugins/values.yaml
@@ -273,14 +273,14 @@ k9:
   replicas: 1
   frontend:
     image:
-      repository: us.gcr.io/ksoc-public/ksoc-frontend-agent
-      tag: v0.0.33
+      repository: public.ecr.aws/n8h5y2v5/rad-security/rad-k9-frontend-agent
+      tag: v0.0.37
     # -- The interval in which the agent polls the backend for new actions.
     agentActionPollInterval: "5s"
   backend:
     image:
-      repository: us.gcr.io/ksoc-public/ksoc-backend-agent
-      tag: v0.0.33
+      repository: public.ecr.aws/n8h5y2v5/rad-security/rad-k9-backend-agent
+      tag: v0.0.37
   resources:
     limits:
       cpu: 250m


### PR DESCRIPTION
Updates K9 image repos in this Helm Chart to use ECR instead of GCR 

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

#### Special notes for your reviewer

#### Checklist

- [X] [DCO](https://github.com/ksoclabs/ksoc-plugins-helm-chart/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped in [Chart.yaml](./stable/ksoc-plugins/Chart.yaml)
- [X] [README.md.gotmpl](./stable/ksoc-plugins/README.md.gotmpl) and [README.md](./stable/ksoc-plugins/README.md) updated
- [X] [artifacthub.io/changes](./stable/ksoc-plugins/Chart.yaml) section updated
